### PR TITLE
Bulk rewrite complete and ready for beta testers

### DIFF
--- a/aux-optimize.php
+++ b/aux-optimize.php
@@ -333,7 +333,7 @@ function ewww_image_optimizer_aux_images_convert() {
 }
 
 // prepares the bulk operation and includes the javascript functions
-function ewww_image_optimizer_aux_images_script( $hook ) {
+function ewww_image_optimizer_aux_images_script( $hook = '' ) {
 	ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
 	// make sure we are being called from the proper page
 	if ( 'ewww-image-optimizer-auto' !== $hook && empty( $_REQUEST['ewww_scan'] ) ) {

--- a/aux-optimize.php
+++ b/aux-optimize.php
@@ -36,8 +36,8 @@ function ewww_image_optimizer_aux_images () {
 	}
 	date_default_timezone_set( $site_timezone );
 	?>
-	<h2 class="ewww-bulk-aux"><?php esc_html_e( 'Optimize Everything Else', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></h2>
-		<div id="ewww-aux-forms"><p class="ewww-aux-info ewww-bulk-info"><?php esc_html_e( 'Use this tool to optimize images outside of the Media Library and galleries where we have full integration. Examples: theme images, BuddyPress, WP Symposium, and any folders that you have specified on the settings page.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
+<!--	<h2 class="ewww-bulk-aux"><?php esc_html_e( 'Optimize Everything Else', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></h2>-->
+		<div id="ewww-aux-forms"><!--<p class="ewww-aux-info ewww-bulk-info"><?php esc_html_e( 'Use this tool to optimize images outside of the Media Library and galleries where we have full integration. Examples: theme images, BuddyPress, WP Symposium, and any folders that you have specified on the settings page.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>-->
 		<?php if ( ! empty( $db_convert ) ) { ?>
 			<p class="ewww-bulk-info"><?php esc_html_e( 'The database schema has changed, you need to convert to the new format.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
 			<form method="post" id="ewww-aux-convert" class="ewww-bulk-form" action="">
@@ -49,21 +49,21 @@ function ewww_image_optimizer_aux_images () {
 			<p id="ewww-nothing" class="ewww-bulk-info" style="display:none"><?php esc_html_e( 'There are no images to optimize.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
 			<p id="ewww-scanning" class="ewww-bulk-info" style="display:none"><?php esc_html_e( 'Scanning, this could take a while', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>&nbsp;<img src='<?php echo $loading_image; ?>' alt='loading'/></p>
 		<?php if ( ! empty( $lastaux ) ) { ?>
-			<p id="ewww-lastaux" class="ewww-bulk-info"><?php printf( esc_html__( 'Last optimization was completed on %1$s at %2$s and optimized %3$d images', EWWW_IMAGE_OPTIMIZER_DOMAIN ), date( get_option( 'date_format' ), $lastaux[0] ), date( get_option( 'time_format' ), $lastaux[0] ), (int) $lastaux[1] ); ?></p>
+	<!--		<p id="ewww-lastaux" class="ewww-bulk-info"><?php printf( esc_html__( 'Last optimization was completed on %1$s at %2$s and optimized %3$d images', EWWW_IMAGE_OPTIMIZER_DOMAIN ), date( get_option( 'date_format' ), $lastaux[0] ), date( get_option( 'time_format' ), $lastaux[0] ), (int) $lastaux[1] ); ?></p>-->
 		<?php } ?>
-			<form id="ewww-aux-start" class="ewww-bulk-form" method="post" action="">
+<!--			<form id="ewww-aux-start" class="ewww-bulk-form" method="post" action="">
 				<input id="ewww-aux-first" type="submit" class="button-secondary action" value="<?php echo $button_text; ?>" />
 				<input id="ewww-aux-again" type="submit" class="button-secondary action" style="display:none" value="<?php esc_attr_e( 'Optimize Again', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>" />
-			</form>
+			</form>-->
 <?php		// if the 'bulk resume' option was not empty, offer to reset it so the user can start back from the beginning
 		if ( ! empty( $aux_resume ) && $aux_resume !== 'scanning' ) {
 ?>
-			<p id="ewww-aux-reset-desc" class="ewww-bulk-info"><?php esc_html_e( 'If you would like to start over again, press the Reset Status button to reset the bulk operation status.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
+			<!--<p id="ewww-aux-reset-desc" class="ewww-bulk-info"><?php esc_html_e( 'If you would like to start over again, press the Reset Status button to reset the bulk operation status.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
 			<form id="ewww-aux-reset" class="ewww-bulk-form" method="post" action="">
 				<?php wp_nonce_field( 'ewww-image-optimizer-aux-images-reset', 'ewww_wpnonce' ); ?>
 				<input type="hidden" name="ewww_reset_aux" value="1">
 				<button type="submit" class="button-secondary action"><?php esc_html_e( 'Reset Status', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></button>
-			</form>
+			</form>-->
 <?php		} 
 		if ( empty( $already_optimized ) ) {
 			$display = ' style="display:none"';
@@ -478,6 +478,7 @@ function ewww_image_optimizer_aux_images_script( $hook = '' ) {
 		ewwwio_debug_message( "found $image_count images to optimize while scanning" );
 	}
 	update_option( 'ewww_image_optimizer_aux_folders_completed', array(), false );
+	update_option( 'ewww_image_optimizer_aux_resume', '' );
 	ewww_image_optimizer_debug_log();
 	if ( ! empty( $_REQUEST['ewww_scan'] ) ) {
 		ewwwio_memory( __FUNCTION__ );

--- a/aux-optimize.php
+++ b/aux-optimize.php
@@ -477,6 +477,7 @@ function ewww_image_optimizer_aux_images_script( $hook = '' ) {
 	}
 	update_option( 'ewww_image_optimizer_aux_folders_completed', array(), false );
 	update_option( 'ewww_image_optimizer_aux_resume', '' );
+	update_option( 'ewww_image_optimizer_bulk_resume', '' );
 	ewww_image_optimizer_debug_log();
 	if ( ! empty( $_REQUEST['ewww_scan'] ) ) {
 		ewwwio_memory( __FUNCTION__ );

--- a/aux-optimize.php
+++ b/aux-optimize.php
@@ -46,8 +46,6 @@ function ewww_image_optimizer_aux_images () {
 				<button id="ewww-table-convert" type="submit" class="button-secondary action"><?php esc_html_e( 'Convert Table', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></button>
 			</form>
 		<?php } ?>	
-			<p id="ewww-nothing" class="ewww-bulk-info" style="display:none"><?php esc_html_e( 'There are no images to optimize.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
-			<p id="ewww-scanning" class="ewww-bulk-info" style="display:none"><?php esc_html_e( 'Scanning, this could take a while', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>&nbsp;<img src='<?php echo $loading_image; ?>' alt='loading'/></p>
 		<?php if ( ! empty( $lastaux ) ) { ?>
 	<!--		<p id="ewww-lastaux" class="ewww-bulk-info"><?php printf( esc_html__( 'Last optimization was completed on %1$s at %2$s and optimized %3$d images', EWWW_IMAGE_OPTIMIZER_DOMAIN ), date( get_option( 'date_format' ), $lastaux[0] ), date( get_option( 'time_format' ), $lastaux[0] ), (int) $lastaux[1] ); ?></p>-->
 		<?php } ?>
@@ -482,7 +480,8 @@ function ewww_image_optimizer_aux_images_script( $hook = '' ) {
 	ewww_image_optimizer_debug_log();
 	if ( ! empty( $_REQUEST['ewww_scan'] ) ) {
 		ewwwio_memory( __FUNCTION__ );
-		die( json_encode( array( 'ready' => $image_count ) ) );
+		$ready_msg = sprintf( esc_html__( 'There are %d images ready to optimize.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $image_count );
+		die( json_encode( array( 'ready' => $image_count, 'message' => $ready_msg ) ) );
 	}
 	ewwwio_memory( __FUNCTION__ );
 	return $image_count;

--- a/background.php
+++ b/background.php
@@ -234,10 +234,18 @@ class EWWWIO_Async_Request extends WP_Async_Request {
 		} else {
 			$size = $_POST['ewwwio_size'];
 		}
+		if ( empty( $_POST['ewwwio_id'] ) ) {
+			$id = 0;
+		} else {
+			$id = (int) $_POST['ewwwio_id'];
+		}
+		global $ewww_image;
 		if ( ! empty( $_POST['ewwwio_path'] ) && $size == 'full' ) {
 			$file_path = $this->find_file( $_POST['ewwwio_path'] );
 			if ( ! empty( $file_path ) ) {
 				ewwwio_debug_message( "processing async optimization request for {$_POST['ewwwio_path']}" );
+				$ewww_image = new EWWW_Image( $id, 'media', $file_path );
+				$ewww_image->resize = 'full';
 				list( $file, $msg, $conv, $original ) = ewww_image_optimizer( $file_path, 1, false, false, true );
 			} else {
 				ewwwio_debug_message( "could not process async optimization request for {$_POST['ewwwio_path']}" );
@@ -246,6 +254,8 @@ class EWWWIO_Async_Request extends WP_Async_Request {
 			$file_path = $this->find_file( $_POST['ewwwio_path'] );
 			if ( ! empty( $file_path ) ) {
 				ewwwio_debug_message( "processing async optimization request for {$_POST['ewwwio_path']}" );
+				$ewww_image = new EWWW_Image( $id, 'media', $file_path );
+				$ewww_image->resize = ( empty( $size ) ? null : $size );
 				list( $file, $msg, $conv, $original ) = ewww_image_optimizer( $file_path );
 			} else {
 				ewwwio_debug_message( "could not process async optimization request for {$_POST['ewwwio_path']}" );

--- a/bulk.php
+++ b/bulk.php
@@ -6,7 +6,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 function ewww_image_optimizer_bulk_preview() {
 	ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
 	// retrieve the attachment IDs that were pre-loaded in the database
-	list( $fullsize_count, $unoptimized_count, $resize_count, $unoptimized_resize_count ) = ewww_image_optimizer_count_optimized( 'media' );
 ?>
 	<div class="wrap"> 
 	<h1>
@@ -18,8 +17,10 @@ function ewww_image_optimizer_bulk_preview() {
 	// Retrieve the value of the 'bulk resume' option and set the button text for the form to use
 	$resume = get_option( 'ewww_image_optimizer_bulk_resume' );
 	if ( empty( $resume ) ) {
-		$button_text = esc_attr__( 'Scan and optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN );
+		$fullsize_count = ewww_image_optimizer_count_optimized( 'media' );
+		$button_text = esc_attr__( 'Start optimizing', EWWW_IMAGE_OPTIMIZER_DOMAIN );
 	} else {
+		$fullsize_count = ewww_image_optimizer_aux_images_table_count_pending();
 		$button_text = esc_attr__( 'Resume previous optimization', EWWW_IMAGE_OPTIMIZER_DOMAIN );
 	}
 	$loading_image = plugins_url( '/images/wpspin.gif', __FILE__ );
@@ -65,22 +66,30 @@ function ewww_image_optimizer_bulk_preview() {
 			echo '<p>' . esc_html__( 'You do not appear to have uploaded any images yet.', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . '</p>';
 		} else { ?>
 			<div id="ewww-bulk-forms">
-<?php			if ( ! $resize_count && ! $unoptimized_count && ! $unoptimized_resize_count ) { 
-				if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-					$credits_needed = $fullsize_count * ( count( get_intermediate_image_sizes() ) + 1 );
-				} ?>
-				<p class="ewww-media-info ewww-bulk-info"><?php printf( esc_html__( '%1$d images in the Media Library have been selected, unable to determine how many resizes and how many are unoptimized.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $fullsize_count ); ?> <?php if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && $credits_needed > 0 ) { printf( esc_html__( 'This could require approximately %d image credits to complete.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $credits_needed ); } ?><br />
+<?php			if ( $resume ) { 
+				//if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
+				//	$credits_needed = $fullsize_count * ( count( get_intermediate_image_sizes() ) + 1 );
+				//} ?>
+				<p class="ewww-media-info ewww-bulk-info"><?php printf( esc_html__( 'There are %d images ready to optimize.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $fullsize_count ); ?> <?php //if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && $credits_needed > 0 ) { printf( esc_html__( 'This could require approximately %d image credits to complete.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $credits_needed ); } ?></p>
 <?php			} else { 
-				if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-					$credits_needed = $unoptimized_count + $unoptimized_resize_count;
-				} ?>
-				<p class="ewww-media-info ewww-bulk-info"><?php printf( esc_html__( '%1$d images in the Media Library have been selected (%2$d unoptimized), with %3$d resizes (%4$d unoptimized).', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $fullsize_count, $unoptimized_count, $resize_count, $unoptimized_resize_count ); ?>  <?php if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && $credits_needed > 0 ) { printf( esc_html__( 'This could require approximately %d image credits to complete.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $credits_needed ); } ?><br />
-<?php			}
-			esc_html_e( 'The active theme, BuddyPress, WP Symposium, and folders that you have configured will also be scanned for unoptimized images.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
-			<?php //esc_html_e( 'Previously optimized images will be skipped by default.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
-			<form id="ewww-bulk-start" class="ewww-bulk-form" method="post" action="">
-				<input id="ewww-bulk-first" type="submit" class="button-primary action" value="<?php echo $button_text; ?>" />
-				<input id="ewww-bulk-again" type="submit" class="button-secondary action" style="display:none" value="<?php esc_attr_e( 'Optimize Again', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>" />
+				//if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
+				//	$credits_needed = $unoptimized_count + $unoptimized_resize_count;
+				//} ?>
+				<p class="ewww-media-info ewww-bulk-info"><?php printf( esc_html__( '%1$d images in the Media Library have been selected.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $fullsize_count ); ?><br />
+				<?php esc_html_e( 'The active theme, BuddyPress, WP Symposium, and folders that you have configured will also be scanned for unoptimized images.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
+				<!--<p class="ewww-media-info ewww-bulk-info"><?php // printf( esc_html__( '%1$d images in the Media Library have been selected (%2$d unoptimized), with %3$d resizes (%4$d unoptimized).', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $fullsize_count, $unoptimized_count, $resize_count, $unoptimized_resize_count ); ?>  <?php // if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && $credits_needed > 0 ) { printf( esc_html__( 'This could require approximately %d image credits to complete.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $credits_needed ); } ?><br />-->
+<?php			} ?>
+			<?php //esc_html_e( 'Previously optimized images will be skipped by default.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>
+			<p id="ewww-nothing" class="ewww-bulk-info" style="display:none"><?php esc_html_e( 'There are no images to optimize.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
+			<p id="ewww-scanning" class="ewww-bulk-info" style="display:none"><?php esc_html_e( 'Scanning, this could take a while', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>&nbsp;<img src='<?php echo $loading_image; ?>' alt='loading'/></p>
+			<form id="ewww-aux-start" class="ewww-bulk-form" method="post" action="">
+<?php				if ( ! $resume ) { ?>
+				<input id="ewww-aux-first" type="submit" class="button-primary action" value="<?php esc_attr_e( 'Scan for unoptimized images', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>" />
+				<?php } ?>
+				<input id="ewww-aux-again" type="submit" class="button-secondary action" style="display:none" value="<?php esc_attr_e( 'Scan Again', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>" />
+			</form>
+			<form id="ewww-bulk-start" class="ewww-bulk-form" <?php if ( ! $resume ) { ?>style="display:none" <?php } ?>method="post" action="">
+				<input id="ewww-aux-first" type="submit" class="button-primary action" value="<?php echo $button_text; ?>" />
 			</form>
 <?php		}
 		// if the 'bulk resume' option was not empty, offer to reset it so the user can start back from the beginning
@@ -141,6 +150,7 @@ function ewww_image_optimizer_count_optimized( $gallery, $return_ids = false ) {
 			} else {
 				$full_count = $wpdb->get_var( "SELECT COUNT(ID) FROM $wpdb->posts WHERE (post_type = 'attachment' OR post_type = 'ims_image') AND (post_mime_type LIKE '%%image%%' OR post_mime_type LIKE '%%pdf%%')" );
 			}
+			return $full_count;
 			$offset = 0;
 			// retrieve all the image attachment metadata from the database
 			while ( $attachments = $wpdb->get_results( "SELECT metas.meta_value,post_id FROM $wpdb->postmeta metas INNER JOIN $wpdb->posts posts ON posts.ID = metas.post_id WHERE (posts.post_mime_type LIKE '%%image%%' OR posts.post_mime_type LIKE '%%pdf%%') AND metas.meta_key = '_wp_attachment_metadata' $attachment_query LIMIT $offset,$max_query", ARRAY_N ) ) {
@@ -172,6 +182,7 @@ function ewww_image_optimizer_count_optimized( $gallery, $return_ids = false ) {
 						continue;
 					}
 					if ( empty( $meta['ewww_image_optimizer'] ) ) {
+						ewwwio_debug_message( "{$attachment[1]} {$meta['file']}" );
 						$unoptimized_full++;
 						$ids[] = $attachment[1];
 					}
@@ -414,7 +425,7 @@ function ewww_image_optimizer_bulk_script( $hook ) {
 	// submit a couple variables to the javascript to work with
 	wp_localize_script('ewwwbulkscript', 'ewww_vars', array(
 			'_wpnonce' => wp_create_nonce( 'ewww-image-optimizer-bulk' ),
-			'attachments' => $attachment_count,
+			'attachments' => ewww_image_optimizer_aux_images_table_count_pending(),
 			'image_count' => $image_count,
 			'count_string' => sprintf( esc_html__( '%d images', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $image_count ),
 			'scan_fail' => esc_html__( 'Operation timed out, you may need to increase the max_execution_time for PHP', EWWW_IMAGE_OPTIMIZER_DOMAIN ),

--- a/bulk.php
+++ b/bulk.php
@@ -886,7 +886,7 @@ function ewww_image_optimizer_bulk_loop() {
 		$output['results'] .= "$msg</p>"; // TODO: make sure it looks nice, or we may want to tweak the line breaks a bit
 
 		// if this is a full size image and it was converted
-		if ( $image->resize == 'full' && $converted !== false ) {
+		if ( $image->resize == 'full' && ( $image->increment !== false || $converted !== false ) ) {
 			if ( ! $meta || ! is_array( $meta ) ) {
 				$meta = wp_get_attachment_metadata( $image->attachment_id );
 			}

--- a/bulk.php
+++ b/bulk.php
@@ -12,14 +12,13 @@ function ewww_image_optimizer_bulk_preview() {
 	<h1>
 <?php 		esc_html_e( 'Bulk Optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN );
 		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-		//	ewww_image_optimizer_cloud_verify(); 
 			echo '<span><a id="ewww-bulk-credits-available" target="_blank" class="page-title-action" style="float:right;" href="https://ewww.io/my-account/">' . esc_html__( 'Image credits available:', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . ' ' . ewww_image_optimizer_cloud_quota() . '</a></span>';
 		}
 	echo '</h1>';
 	// Retrieve the value of the 'bulk resume' option and set the button text for the form to use
 	$resume = get_option( 'ewww_image_optimizer_bulk_resume' );
 	if ( empty( $resume ) ) {
-		$button_text = esc_attr__( 'Start optimizing', EWWW_IMAGE_OPTIMIZER_DOMAIN );
+		$button_text = esc_attr__( 'Scan and optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN );
 	} else {
 		$button_text = esc_attr__( 'Resume previous optimization', EWWW_IMAGE_OPTIMIZER_DOMAIN );
 	}
@@ -94,6 +93,7 @@ function ewww_image_optimizer_bulk_preview() {
 			</form>
 <?php		endif;
 	echo '</div>';
+	ewww_image_optimizer_media_scan();
 	ewwwio_memory( __FUNCTION__ );
 	ewww_image_optimizer_aux_images();
 }
@@ -119,11 +119,16 @@ function ewww_image_optimizer_count_optimized( $gallery, $return_ids = false ) {
 	switch ( $gallery ) {
 		case 'media':
 			$ids = array();
+			$resume = get_option( 'ewww_image_optimizer_bulk_resume' );
 			// see if we were given attachment IDs to work with via GET/POST
-		        if ( ! empty( $_REQUEST['ids'] ) || get_option( 'ewww_image_optimizer_bulk_resume' ) ) {
+		        if ( ! empty( $_REQUEST['ids'] ) || $resume ) {
 				ewwwio_debug_message( 'we have received attachment ids via $_REQUEST' );
 				// retrieve the attachment IDs that were pre-loaded in the database
-				$attachment_ids = get_option( 'ewww_image_optimizer_bulk_attachments' );
+				if ( 'scanning' == $resume ) {
+					$attachment_ids = array_merge( get_option( 'ewww_image_optimizer_scanning_attachments' ), get_option( 'ewww_image_optimizer_bulk_attachments' ) );
+				} else {
+					$attachment_ids = get_option( 'ewww_image_optimizer_bulk_attachments' );
+				}
 				if ( ! empty( $attachment_ids ) ) {
 					$full_count = count( $attachment_ids );
 					while ( $attachment_ids && $attachment_query_count < $max_query ) {
@@ -141,7 +146,6 @@ function ewww_image_optimizer_count_optimized( $gallery, $return_ids = false ) {
 				ewwwio_debug_message( "fetched " . count( $attachments ) . " attachments starting at $offset" );
 				$disabled_sizes = ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_resizes_opt' );
 				foreach ( $attachments as $attachment ) {
-//					ewwwio_debug_message( 'checking attachment ' . $attachment[1] );
 					$meta = maybe_unserialize( $attachment[0] );
 					if ( empty( $meta ) ) {
 						ewwwio_debug_message( 'empty meta' );
@@ -155,30 +159,22 @@ function ewww_image_optimizer_count_optimized( $gallery, $return_ids = false ) {
 						ewwwio_debug_message( 'checking mime via get_post...' );
 					}
 					if ( $mime == 'image/jpeg' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) == 0 ) {
-//						ewwwio_debug_message( 'optimization for this type disabled, skipping' );
 						continue;
 					}
 					if ( $mime == 'image/png' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) == 0 ) {
-//						ewwwio_debug_message( 'optimization for this type disabled, skipping' );
 						continue;
 					}
 					if ( $mime == 'image/gif' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ) == 0 ) {
-//						ewwwio_debug_message( 'optimization for this type disabled, skipping' );
 						continue;
 					}
 					if ( $mime == 'application/pdf' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) == 0 ) {
-//						ewwwio_debug_message( 'optimization for this type disabled, skipping' );
 						continue;
 					}
 					if ( empty( $meta['ewww_image_optimizer'] ) ) {
-//						ewwwio_debug_message( 'no optimization status, counting as unoptimized full: ' . $attachment[1] );
-//						ewwwio_debug_message( print_r( $meta, true ) );
 						$unoptimized_full++;
 						$ids[] = $attachment[1];
 					}
 					if ( ! empty( $meta['ewww_image_optimizer'] ) && preg_match( '/' . __('License exceeded', EWWW_IMAGE_OPTIMIZER_DOMAIN) . '/', $meta['ewww_image_optimizer'] ) ) {
-//						ewwwio_debug_message( 'optimization status license exceeded, counting as unoptimized full: ' . $attachment[1] );
-//						ewwwio_debug_message( print_r( $meta, true ) );
 						$unoptimized_full++;
 						$ids[] = $attachment[1];
 					}
@@ -198,7 +194,6 @@ function ewww_image_optimizer_count_optimized( $gallery, $return_ids = false ) {
 						}
 					}
 				}
-		//		$full_count += count( $attachments );
 				$offset += $max_query;
 				if ( ! empty( $attachment_ids ) ) {
 					$attachment_query = '';
@@ -359,10 +354,14 @@ function ewww_image_optimizer_bulk_script( $hook ) {
 	}
 	// check the 'bulk resume' option
 	$resume = get_option('ewww_image_optimizer_bulk_resume');
+	$scanning = get_option('ewww_image_optimizer_aux_resume');
+	$attachments = get_option( 'ewww_image_optimizer_scanning_attachments' );
 	// see if we were given attachment IDs to work with via GET/POST
+	$ids = array();
         if ( ! empty( $_REQUEST['ids'] ) && ( preg_match( '/^[\d,]+$/', $_REQUEST['ids'], $request_ids ) || is_numeric( $_REQUEST['ids'] ) ) ) {
+		ewww_image_optimizer_delete_pending();
 		if ( is_numeric( $_REQUEST['ids'] ) ) {
-			$ids = (int) $_REQUEST['ids'];
+			$ids[] = (int) $_REQUEST['ids'];
 		} else {
 			$ids = explode( ',', $request_ids[0] );
 		}
@@ -383,16 +382,19 @@ function ewww_image_optimizer_bulk_script( $hook ) {
 		// unset the 'bulk resume' option since we were given specific IDs to optimize
 		update_option( 'ewww_image_optimizer_bulk_resume', '' );
         // check if there is a previous bulk operation to resume
-        } elseif ( ! empty( $resume ) ) {
-		// retrieve the attachment IDs that have not been finished from the 'bulk attachments' option
-		$attachments = get_option( 'ewww_image_optimizer_bulk_attachments' );
+//        } elseif ( $scanning == 'scanning' ) {
+		// retrieve the attachment IDs that have not been finished from the 'scanning attachments' option
+//		$attachments = get_option( 'ewww_image_optimizer_scanning_attachments' );
+        } elseif ( $scanning ) {
+		// do nothing
+		$attachments = array();
 	// since we aren't resuming, and weren't given a list of IDs, we will optimize everything
-        } else {
+        } elseif ( empty( $attachments ) ) {
                 // load up all the image attachments we can find
 		$attachments = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE (post_type = 'attachment' OR post_type = 'ims_image') AND (post_mime_type LIKE '%%image%%' OR post_mime_type LIKE '%%pdf%%') ORDER BY ID DESC" );
         }
 	// store the attachment IDs we retrieved in the 'bulk_attachments' option so we can keep track of our progress in the database
-	update_option( 'ewww_image_optimizer_bulk_attachments', $attachments, false );
+	update_option( 'ewww_image_optimizer_scanning_attachments', $attachments, false );
 	wp_enqueue_script( 'ewwwbulkscript', plugins_url( '/includes/eio.js', __FILE__ ), array( 'jquery', 'jquery-ui-slider', 'jquery-ui-progressbar', 'postbox', 'dashboard' ), EWWW_IMAGE_OPTIMIZER_VERSION );
 	// number of images in the ewwwio_table (previously optimized images)
 	$image_count = ewww_image_optimizer_aux_images_table_count();
@@ -419,18 +421,308 @@ function ewww_image_optimizer_bulk_script( $hook ) {
 	ewwwio_memory( __FUNCTION__ );
 }
 
-// find the number of images in the ewwwio_images table
-function ewww_image_optimizer_aux_images_table_count() {
+// retrieve image counts for the bulk process
+function ewww_image_optimizer_media_scan() {
+	ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
 	global $wpdb;
-	$count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->ewwwio_images WHERE image_size IS NOT NULL" );
-	if ( ! empty( $_REQUEST['ewww_inline'] ) ) {
-		echo $count;
-		ewwwio_memory( __FUNCTION__ );
-		die();
+	$image_count = 0;
+	$reset_count = 0;
+	$attachment_query = '';
+	$images = array();
+	$attachment_images = array();
+	$reset_images = array();
+	ewwwio_debug_message( "scanning for media attachments" );
+	// retrieve the time when the optimizer starts
+	$started = microtime( true );
+	ewwwio_debug_message( 'building optimized list' );
+	$query = "SELECT id,path,image_size,pending,attachment_id FROM $wpdb->ewwwio_images";
+	$already_optimized = $wpdb->get_results( $query, ARRAY_A );
+	$optimized_list = array();
+	foreach ( $already_optimized as $optimized ) {
+		$optimized_path = $optimized['path'];
+		$optimized_list[ $optimized_path ]['image_size'] = $optimized['image_size'];
+		$optimized_list[ $optimized_path ]['id'] = $optimized['id'];
+		$optimized_list[ $optimized_path ]['pending'] = $optimized['pending'];
+		$optimized_list[ $optimized_path ]['attachment_id'] = $optimized['attachment_id'];
 	}
+
+	$max_query = apply_filters( 'ewww_image_optimizer_count_optimized_queries', 3000 );
+	$max_query = (int) $max_query;
+	$attachment_query_count = 0;
+	// We WILL have IDs to work with, we then need to grab 'max_query' (3000) of the IDs to query metadata
+	// the while() loop might need to change to something like while( there are attachment IDs left to scan )
+	//$resume = get_option( 'ewww_image_optimizer_bulk_resume' );
+	$attachment_ids = get_option( 'ewww_image_optimizer_scanning_attachments' );
+	if ( empty( $attachment_ids ) ) {
+		// run aux script to scan for additional images
+		ewww_image_optimizer_aux_images_script();
+	}
+	$disabled_sizes = ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_resizes_opt' );
+	while ( microtime( true ) - $started < 20 && count( $attachment_ids ) ) {
+		if ( ! empty( $attachment_ids ) && is_array( $attachment_ids ) ) {
+			ewwwio_debug_message( 'remaining items: ' . count( $attachment_ids ) );
+			// retrieve the attachment IDs that were pre-loaded in the database
+			$selected_ids = array_splice( $attachment_ids, 0, $max_query );
+			ewwwio_debug_message( 'selected items: ' . count( $selected_ids ) );
+			$attachments_in = "'" . implode( "','", $selected_ids ) . "'";
+					/*while ( $selected_ids ) { //&& $attachment_query_count < $max_query ) {
+						$attachment_query .= "'" . array_pop( $attachment_ids ) . "',";
+						$attachment_query_count++;
+					}
+					$attachment_query = 'AND metas.post_id IN (' . substr( $attachment_query, 0, -1 ) . ')';*/
+		} else {
+//				$full_count = $wpdb->get_var( "SELECT COUNT(ID) FROM $wpdb->posts WHERE (post_type = 'attachment' OR post_type = 'ims_image') AND (post_mime_type LIKE '%%image%%' OR post_mime_type LIKE '%%pdf%%')" );
+			ewwwio_debug_message( 'no array found' );
+			// TODO: make sure to throw appropriate errors in json (if we can't overcome or ignore them)
+			die( json_encode( array( 'error' => 'no array of attachment IDs found' ) ) );
+		}
+//			if ( ! empty( $_REQUEST['ewww_offset'] ) ) {
+//				$offset = (int) $_REQUEST['ewww_offset'];
+//			} else {
+//				$offset = 0;
+//			}
+
+		// retrieve image attachment metadata from the database (in batches)
+		$attachments = $wpdb->get_results( "SELECT metas.post_id,metas.meta_key,metas.meta_value,posts.post_mime_type FROM $wpdb->postmeta metas INNER JOIN $wpdb->posts posts ON posts.ID = metas.post_id WHERE (posts.post_mime_type LIKE '%%image%%' OR posts.post_mime_type LIKE '%%pdf%%') AND metas.post_id IN ($attachments_in)", ARRAY_A );
+		ewwwio_debug_message( "fetched " . count( $attachments ) . " attachment meta items" );
+		foreach ( $attachments as $attachment ) {
+			if ( '_wp_attached_file' == $attachment['meta_key'] ) {
+				$attachment_meta[ $attachment['post_id'] ]['_wp_attached_file'] = $attachment['meta_value'];
+			} elseif ( '_wp_attachment_metadata' != $attachment['meta_key'] ) {
+				if ( ! empty( $attachment['post_mime_type'] ) ) {
+					$attachment_meta[ $attachment['post_id'] ]['type'] = $attachment['post_mime_type'];
+				}
+				//ewwwio_debug_message( print_r( $attachment, true ) );
+				continue;
+			}
+			$attachment_meta[ $attachment['post_id'] ]['meta'] = $attachment['meta_value'];
+			$attachment_meta[ $attachment['post_id'] ]['type'] = $attachment['post_mime_type'];
+		}
+
+		ewwwio_debug_message( "validated " . count( $attachment_meta ) . " attachment meta items" );
+		ewwwio_debug_message( 'remaining items after selection: ' . count( $attachment_ids ) );
+		foreach ( $selected_ids as $selected_id ) {
+			if ( empty( $attachment_meta[ $selected_id ]['meta'] ) ) {
+				ewwwio_debug_message( "empty meta for $selected_id" );
+				$meta = array();
+				//continue;
+			} else {
+				$meta = maybe_unserialize( $attachment_meta[ $selected_id ]['meta'] );
+			}
+			if ( ! empty( $attachment_meta[ $selected_id ]['type'] ) ) {
+				$mime = $attachment_meta[ $selected_id ]['type'];
+			} elseif ( ! empty( $meta['file'] ) ) {
+				$mime = ewww_image_optimizer_quick_mimetype( $meta['file'] );
+				ewwwio_debug_message( 'got quick mime via filename' );
+			} elseif ( ! empty( $selected_id ) ) {
+				$mime = get_post_mime_type( $selected_id );
+				ewwwio_debug_message( 'checking mime via get_post...' );
+			}
+			if ( empty( $mime ) ) {
+				ewwwio_debug_message( "missing mime for $selected_id" );
+			}
+
+			if ( 'application/pdf' != $mime // NOT a pdf
+				&& ( // AND
+					empty( $meta ) // meta is empty
+					|| ( is_string( $meta ) && 'processing' == $meta ) // OR the string 'processing'
+					|| ( is_array( $meta ) && ! empty( $meta[0] ) && 'processing' == $meta[0] ) // OR array( 'processing )
+				)
+			) {
+				// rebuild meta
+				ewwwio_debug_message( "attempting to rebuild attachment meta for $selected_id" );
+				$new_meta = ewww_image_optimizer_rebuild_meta( $selected_id );
+				if ( is_array( $new_meta ) ) {
+					$meta = $new_meta;
+				} else {
+					$meta = array();
+				}
+			}
+
+			if ( $mime == 'image/jpeg' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) == 0 ) {
+				continue;
+			}
+			if ( $mime == 'image/png' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) == 0 ) {
+				continue;
+			}
+			if ( $mime == 'image/gif' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ) == 0 ) {
+				continue;
+			}
+			if ( $mime == 'application/pdf' && ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) == 0 ) {
+				continue;
+			}
+			//ewwwio_debug_message( print_r( $meta, true ) );
+			//ewwwio_debug_message( "type: $mime" );
+			$attached_file = ( ! empty( $attachment_meta[ $selected_id ]['_wp_attached_file'] ) ? $attachment_meta[ $selected_id ]['_wp_attached_file'] : '' );
+			list( $file_path, $upload_path ) = ewww_image_optimizer_attachment_path( $meta, $selected_id, $attached_file, false );
+			// run a quick fix for as3cf files
+			if ( class_exists( 'Amazon_S3_And_CloudFront' ) && strpos( $file_path, 's3' ) === 0 ) {
+				ewww_image_optimizer_check_table_as3cf( $meta, $selected_id, $file_path );
+			}
+			if ( ! is_file( $file_path ) && ( class_exists( 'WindowsAzureStorageUtil' ) || class_exists( 'Amazon_S3_And_CloudFront' ) ) ) {
+				// construct a $file_path and proceed IF a supported CDN plugin is installed
+				$file_path = get_attached_file( $selected_id );
+				if ( ! $file_path ) {
+					continue;
+				}
+			} elseif ( ! $file_path ) {
+				continue;
+			}
+			$attachment_images['full'] = $file_path;
+			$retina_path = ewww_image_optimizer_hidpi_optimize( $file_path, true );
+			if ( $retina_path ) {
+				$attachment_images['full-retina'] = $retina_path;
+			}
+			// resized versions, so we can continue
+			if ( isset( $meta['sizes'] ) && ewww_image_optimizer_iterable( $meta['sizes'] ) ) {
+				// meta sizes don't contain a path, so we calculate one
+				$base_ims_dir = trailingslashit( dirname( $file_path ) ) . '_resized/';
+				$base_dir = trailingslashit( dirname( $file_path ) );
+				// process each resized version
+				$processed = array();
+				foreach ( $meta['sizes'] as $size => $data ) {
+					ewwwio_debug_message( "checking for size: $size" );
+					if ( strpos( $size, 'webp') === 0 ) {
+						continue;
+					}
+					if ( ! empty( $disabled_sizes[ $size ] ) ) {
+						continue;
+					}
+					if ( empty( $data['file'] ) ) {
+						continue;
+					}
+
+					$ims_path = $base_ims_dir . $data['file'];
+					if ( file_exists( $ims_path ) ) {
+						// we reset base_dir, because base_dir potentially gets overwritten with base_ims_dir
+						$base_dir = trailingslashit( dirname( $file_path ) );
+						$ims_temp_path = $base_dir . $data['file']; // formerly $image_path
+						ewwwio_debug_message( "ims path: $ims_path" );
+						if ( isset( $optimized_list[ $ims_temp_path ] ) ) {
+						/*	ewwwio_debug_message( "possibly need to replace $ims_temp_path" );
+							if ( isset( $optimized_list[ $ims_path ] ) ) {
+								ewwwio_debug_message( "we got a dup: {$optimized_list[ $ims_path ]['id']}" );
+							}*/
+							$optimized_list[ $ims_path ] = $optimized_list[ $ims_temp_path ];
+							ewwwio_debug_message( "updating record {$optimized_list[ $ims_temp_path ]['id']} with $ims_path" );
+							// store info on the current image for future reference
+							$wpdb->update( $wpdb->ewwwio_images,
+								array(
+									'path' => $ims_path,
+								),
+								array(
+									'id' => $optimized_list[ $ims_temp_path ]['id'],
+								));
+							unset( $optimized_list[ $ims_temp_path ] );
+						}
+						$base_dir = $base_ims_dir;
+					}
+
+					// check through all the sizes we've processed so far
+					foreach ( $processed as $proc => $scan ) {
+						// if a previous resize had identical dimensions
+						if ( $scan['height'] == $data['height'] && $scan['width'] == $data['width'] ) {
+							// found a duplicate resize
+							continue( 2 );
+							//$dup_size = true;
+							// point this resize at the same image as the previous one
+							//$meta['sizes'][ $size ]['file'] = $meta['sizes'][ $proc ]['file'];
+							// and tell the user we didn't do any further optimization
+							//$meta['sizes'][ $size ]['ewww_image_optimizer'] = __( 'No savings', EWWW_IMAGE_OPTIMIZER_DOMAIN );
+						}
+					}
+					$resize_path = $base_dir . $data['file'];
+					if ( is_file( $resize_path ) ) {
+						$attachment_images[ $size ] = $resize_path;
+					}
+					// optimize retina images, if they exist
+					if ( function_exists( 'wr2x_get_retina' ) && $retina_path = wr2x_get_retina( $resize_path ) && is_file( $retina_path ) ) {
+						$attachment_images[ $size . '-retina' ] = $retina_path;
+					} elseif ( $retina_path = ewww_image_optimizer_hidpi_optimize( $resize_path, true ) ) {
+						$attachment_images[ $size . '-retina' ] = $retina_path;
+					}
+					// store info on the sizes we've processed, so we can check the list for duplicate sizes
+					$processed[ $size ]['width'] = $data['width'];
+					$processed[ $size ]['height'] = $data['height'];
+				}
+			}
+
+			// queue sizes from a custom theme
+			if ( isset( $meta['image_meta']['resized_images'] ) && ewww_image_optimizer_iterable( $meta['image_meta']['resized_images'] ) ) {
+				$imagemeta_resize_pathinfo = pathinfo( $file_path );
+				$imagemeta_resize_path = '';
+				foreach ( $meta['image_meta']['resized_images'] as $index => $imagemeta_resize ) {
+					$imagemeta_resize_path = $imagemeta_resize_pathinfo['dirname'] . '/' . $imagemeta_resize_pathinfo['filename'] . '-' . $imagemeta_resize . '.' . $imagemeta_resize_pathinfo['extension'];
+					if ( is_file( $imagemeta_resize_path ) ) {
+						$attachment_images[ 'resized-images-' . $index ] = $imagemeta_resize_path;
+					}
+				}		
+			}
+
+			// and another custom theme
+			if ( isset( $meta['custom_sizes'] ) && ewww_image_optimizer_iterable( $meta['custom_sizes'] ) ) {
+				$custom_sizes_pathinfo = pathinfo( $file_path );
+				$custom_size_path = '';
+				foreach ( $meta['custom_sizes'] as $dimensions => $custom_size ) {
+					$custom_size_path = $custom_sizes_pathinfo['dirname'] . '/' . $custom_size['file'];
+					if ( is_file( $custom_size_path ) ) {
+						$attachment_images[ 'custom-size-' . $dimensions ] = $custom_size_path;
+					}
+				}
+			}
+
+			// check if the files are 'prev opt', pending, or brand new, and then queue the file
+			foreach ( $attachment_images as $size => $file_path ) {
+				if ( isset( $optimized_list[ $file_path ] ) ) {
+					if ( ! empty( $optimized_list[ $file_path ]['pending'] ) ) {
+						ewwwio_debug_message( "pending record for $file_path" );
+						continue;
+					}
+					$image_size = filesize( $file_path );
+					if ( $optimized_list[ $file_path ]['image_size'] == $image_size && empty( $_REQUEST['ewww_force'] ) ) {
+						ewwwio_debug_message( "match found for $file_path" );
+						continue;
+					} else {
+				// TODO: need to queue with filename, PLUS media/gallery type and size name: 'full', medium, etc.
+				// hmm, this could get expensive time-wise, see if there is another place we can trigger a lookup to populate records
+				// perhaps the custom column, as that is where people will expect to see results, and where we plan to query the db anyway
+						$reset_images[] = (int) $optimized_list[ $file_path ]['id'];
+						ewwwio_debug_message( "mismatch found for $file_path, db says " . $optimized_list[ $file_path ]['image_size'] . " vs. current $image_size" );
+					}
+				} else {
+					ewwwio_debug_message( "queuing $file_path" );
+					$image_size = filesize( $file_path );
+					$images[] = "('" . esc_sql( utf8_encode( $file_path ) ) . "','media',$image_size,'$size',1)";
+					$image_count++;
+				}
+				if ( $image_count > 3000 ) {
+					ewwwio_debug_message( 'making a dump run' );
+					// let's dump what we have so far to the db
+					$image_count = 0;
+					$insert_query = "INSERT INTO $wpdb->ewwwio_images (path,gallery,orig_size,resize,pending) VALUES " . implode( ',', $images );
+					$wpdb->query( $insert_query );
+					$images = array();
+				}
+			}
+			$attachment_images = array();
+		}
+		update_option( 'ewww_image_optimizer_scanning_attachments', $attachment_ids );
+		update_option( 'ewww_image_optimizer_bulk_attachments', array_merge( get_option( 'ewww_image_optimizer_bulk_attachments' ), $selected_ids ), false );
+	} // endwhile
+	if ( ! empty( $images ) ) {
+		$insert_query = "INSERT INTO $wpdb->ewwwio_images (path,gallery,orig_size,resize,pending) VALUES " . implode( ',', $images );
+		$wpdb->query( $insert_query );
+	}
+	if ( ! empty( $reset_images ) ) {
+		$wpdb->query( "UPDATE $wpdb->ewwwio_images SET pending = 1 WHERE id IN (" . implode( ',', $reset_images ) . ')' );
+	}
+	update_option( 'ewww_image_optimizer_scanning_attachments', $attachment_ids );
+	update_option( 'ewww_image_optimizer_bulk_attachments', array_merge( get_option( 'ewww_image_optimizer_bulk_attachments' ), $selected_ids ), false );
+	$elapsed = microtime( true ) - $started;
+	ewwwio_debug_message( "counting images took $elapsed seconds" );
 	ewwwio_memory( __FUNCTION__ );
-	return $count;
-	
+	return;
+	die( json_encode( array( 'remaining' => count( $attachment_ids ) ) ) );
 }
 
 function ewww_image_optimizer_bulk_quota_update() {
@@ -554,10 +846,6 @@ function ewww_image_optimizer_bulk_loop() {
 	$elapsed = microtime( true ) - $started;
 	// output how much time has elapsed since we started
 	$output['results'] .= sprintf( esc_html__( 'Elapsed: %.3f seconds', EWWW_IMAGE_OPTIMIZER_DOMAIN) . "</p>", $elapsed );
-/*	global $ewww_attachment; // Because we do this up the chain a bit in the resize_from_meta function
-	$ewww_attachment['id'] = $attachment;
-	$ewww_attachment['meta'] = $meta;
-	add_filter( 'w3tc_cdn_update_attachment_metadata', 'ewww_image_optimizer_w3tc_update_files' );*/
 	// update the metadata for the current attachment
 	$meta_saved = wp_update_attachment_metadata( $attachment, $meta );
 	if ( ! $meta_saved ) {

--- a/bulk.php
+++ b/bulk.php
@@ -662,7 +662,7 @@ function ewww_image_optimizer_media_scan( $hook = '' ) {
 						}
 					}
 					$resize_path = $base_dir . $data['file'];
-					if ( is_file( $resize_path ) && 'application/pdf' == $mime ) {
+					if ( is_file( $resize_path ) && 'application/pdf' == $mime && $size == 'full' ) {
 						$attachment_images[ 'pdf-' . $size ] = $resize_path;
 					} elseif ( is_file( $resize_path ) ) {
 						$attachment_images[ $size ] = $resize_path;

--- a/bulk.php
+++ b/bulk.php
@@ -944,7 +944,7 @@ function ewww_image_optimizer_bulk_loop() {
 			$image->converted = $original;
 			$meta['file'] = trailingslashit( dirname( $meta['file'] ) ) . basename( $file );
 			$image->update_converted_attachment( $meta );
-			$meta = $image->convert_sizes( $meta, $converted );
+			$meta = $image->convert_sizes( $meta );
 		}
 
 		$output['results'] .= sprintf( "<p>" . esc_html__( 'Optimized', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . " <strong>%s</strong><br>", esc_html( $image->file ) );

--- a/common.php
+++ b/common.php
@@ -4,9 +4,8 @@
 // TODO: use <picture> element to serve webp
 // TODO: revamp bulk, make it pull only from table, track images by attachment ID as well, so we can pull resize data
 // TODO: maybe move percentages to be built on-demand too, with a dedicated function for portability
-// TODO: see if we can offer a rebuild option, to restore/rebuild broken meta, and also to fill in missing thumbs
+// TODO: see if we can offer a rebuild option, to fill in missing thumbs
 // TODO: look at simple_html_dom_node that wp retina uses for parsing
-// TODO: track the folders scanned successfully so far, and then skip them on a subsequent scan, so that users could list multiple subdirs to complete super large folders
 // TODO: so, if lazy loading support sucks, can we roll our own? that's an image "optimization", right?...
 // TODO: cleanup old options (just uncomment the block and make sure it works properly)
 // TODO: make sure IMS resizes still work
@@ -28,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'EWWW_IMAGE_OPTIMIZER_VERSION', '313.21' );
+define( 'EWWW_IMAGE_OPTIMIZER_VERSION', '313.23' );
 
 // initialize a couple globals
 $ewww_debug = '';
@@ -989,6 +988,7 @@ function ewww_image_optimizer_install_table() {
 		results varchar(55) NOT NULL,
 		image_size int(10) unsigned,
 		orig_size int(10) unsigned,
+		level int(5) unsigned,
 		pending tinyint(1) NOT NULL DEFAULT 0,
 		updates int(5) unsigned,
 		updated timestamp DEFAULT '1971-01-01 00:00:00' ON UPDATE CURRENT_TIMESTAMP,

--- a/common.php
+++ b/common.php
@@ -15,7 +15,7 @@
 // TODO: check new Azure plugin for compatibility with bulk/remote_fetch
 // TODO: if Imsanity is active, disable the resize settings with a notice (instead of just ignoring them like we currently do)
 // TODO: see what Imsanity does different to avoid memory issues on resizing
-
+// TODO: use an object to store optimizer paths/locations to avoid re-checking the binaries on every optimization, not a transient, don't want to risk corrupting something if there are changes in the meantime
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/common.php
+++ b/common.php
@@ -17,6 +17,8 @@
 // TODO: see what Imsanity does different to avoid memory issues on resizing
 // TODO: use an object to store optimizer paths/locations to avoid re-checking the binaries on every optimization, not a transient, don't want to risk corrupting something if there are changes in the meantime
 // TODO: some stuff in nextgen & nextcellent is still using background processing when maybe it should not be
+// TODO: populate id, gallery, size, etc during resize_from_meta
+// TODO: prevent bad ajax errors from firing when we click the toggle on the Optimization Log
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -1303,12 +1303,12 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 	}
 	$file_owner = 'unknown';
 	$file_group = 'unknown';
-	if (function_exists('posix_getpwuid')) {
-		$file_owner = posix_getpwuid(fileowner($file));
+	if ( function_exists( 'posix_getpwuid' ) ) {
+		$file_owner = posix_getpwuid( fileowner( $file ) );
 		$file_owner = $file_owner['name'];
 	}
-	if (function_exists('posix_getgrgid')) {
-		$file_group = posix_getgrgid(filegroup($file));
+	if ( function_exists( 'posix_getgrgid' ) ) {
+		$file_group = posix_getgrgid( filegroup( $file ) );
 		$file_group = $file_group['name'];
 	}
 	ewwwio_debug_message( "permissions: $file_perms, owner: $file_owner, group: $file_group" );
@@ -1356,7 +1356,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 		set_time_limit( 0 );
 	}
 	// if the full-size image was converted
-	if ( $converted ) {
+	if ( $converted ) { // TODO: remove this block in a future release, it should not fire anymore, as resizes will be converted only directly after the full-size is converted
 		ewwwio_debug_message( 'full-size image was converted, need to rebuild filename for meta' );
 		$filenum = $converted;
 		// grab the file extension
@@ -1474,8 +1474,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 			// if optimization is turned ON
 			if ( $optimize ) {
 				ewwwio_debug_message( 'attempting to optimize JPG...' );
-				// generate temporary file-names:
-//				$tempfile = $file . ".tmp"; //non-progressive jpeg
+				// generate temporary file-name:
 				$progfile = $file . ".prog"; // progressive jpeg
 				// check to see if we are supposed to strip metadata (badly named)
 				if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpegtran_copy' ) && ! $keep_metadata ) {
@@ -1485,39 +1484,10 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 					// copy all the metadata
 					$copy_opt = 'all';
 				}
-				// run jpegtran - non-progressive
-//				exec( "$nice " . $tools['JPEGTRAN'] . " -copy $copy_opt -optimize -outfile " . ewww_image_optimizer_escapeshellarg( $tempfile ) . " " . ewww_image_optimizer_escapeshellarg( $file ) );
 				// run jpegtran - progressive
 				exec( "$nice " . $tools['JPEGTRAN'] . " -copy $copy_opt -optimize -progressive -outfile " . ewww_image_optimizer_escapeshellarg( $progfile ) . " " . ewww_image_optimizer_escapeshellarg( $file ) );
-				// check the filesize of the non-progressive JPG
-			//	$non_size = ewww_image_optimizer_filesize( $tempfile );
 				// check the filesize of the progressive JPG
 				$new_size = ewww_image_optimizer_filesize( $progfile );
-//				ewwwio_debug_message( "optimized JPG (non-progresive) size: $non_size" );
-//				ewwwio_debug_message( "optimized JPG (progresive) size: $prog_size" );
-/*				if ( $non_size === false || $prog_size === false ) {
-					$result = __( 'Unable to write file', EWWW_IMAGE_OPTIMIZER_DOMAIN );
-					$new_size = 0;
-				} elseif ( ! $non_size || ! $prog_size) {
-					$result = __( 'Optimization failed', EWWW_IMAGE_OPTIMIZER_DOMAIN );
-					$new_size = 0;
-				} else {
-					// if the progressive file is bigger
-					if ( $prog_size > $non_size ) {
-						// store the size of the non-progessive JPG
-						$new_size = $non_size;
-						if ( is_file( $progfile ) ) {
-							// delete the progressive file
-							unlink( $progfile );
-						}
-					// if the progressive file is smaller or the same
-					} else {
-						// store the size of the progressive JPG
-						$new_size = $prog_size;
-						// replace the non-progressive with the progressive file
-						rename($progfile, $tempfile);
-					}
-				}*/
 				ewwwio_debug_message( "optimized JPG size: $new_size" );
 				// if the best-optimized is smaller than the original JPG, and we didn't create an empty JPG
 				if ( $orig_size > $new_size && $new_size != 0 && ewww_image_optimizer_mimetype( $progfile, 'i' ) == $type ) {
@@ -1830,7 +1800,6 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 			// retrieve the new filesize of the PNG
 			$new_size = ewww_image_optimizer_filesize( $file );
 			// if conversion is on and the PNG doesn't have transparency or the user set a background color to replace transparency
-			//if ( $convert && ( ! ewww_image_optimizer_png_alpha( $file ) || ewww_image_optimizer_jpg_background() ) ) {
 			if ( $convert ) {
 				ewwwio_debug_message( "attempting to convert PNG to JPG: $jpgfile" );
 				if ( empty( $new_size ) ) {
@@ -1914,8 +1883,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 				}
 				// next we need to optimize that JPG if jpegtran is enabled
 				if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) == 10 && file_exists( $jpgfile ) ) {
-					// generate temporary file-names:
-//					$tempfile = $jpgfile . ".tmp"; //non-progressive jpeg
+					// generate temporary file-name:
 					$progfile = $jpgfile . ".prog"; // progressive jpeg
 					// check to see if we are supposed to strip metadata (badly named)
 					if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpegtran_copy' ) && ! $keep_metadata ){
@@ -1925,33 +1893,10 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 						// copy all the metadata
 						$copy_opt = 'all';
 					}
-					// run jpegtran - non-progressive
-//					exec( "$nice " . $tools['JPEGTRAN'] . " -copy $copy_opt -optimize -outfile " . ewww_image_optimizer_escapeshellarg( $tempfile ) . " " . ewww_image_optimizer_escapeshellarg( $jpgfile ) );
 					// run jpegtran - progressive
 					exec( "$nice " . $tools['JPEGTRAN'] . " -copy $copy_opt -optimize -progressive -outfile " . ewww_image_optimizer_escapeshellarg( $progfile ) . " " . ewww_image_optimizer_escapeshellarg( $jpgfile ) );
-					// check the filesize of the non-progressive JPG
-//					$non_size = ewww_image_optimizer_filesize( $tempfile );
-//					ewwwio_debug_message( "non-progressive JPG filesize: $non_size" );
 					// check the filesize of the progressive JPG
 					$opt_jpg_size = ewww_image_optimizer_filesize( $progfile );
-//					ewwwio_debug_message( "progressive JPG filesize: $prog_size" );
-					// if the progressive file is bigger
-					/*if ($prog_size > $non_size) {
-						// store the size of the non-progessive JPG
-						$opt_jpg_size = $non_size;
-						if (is_file($progfile)) {
-							// delete the progressive file
-							unlink($progfile);
-						}
-						ewwwio_debug_message( 'keeping non-progressive JPG' );
-					// if the progressive file is smaller or the same
-					} else {
-						// store the size of the progressive JPG
-						$opt_jpg_size = $prog_size;
-						// replace the non-progressive with the progressive file
-						rename( $progfile, $tempfile );
-						ewwwio_debug_message( 'keeping progressive JPG' );
-					}*/
 					// if the best-optimized is smaller than the original JPG, and we didn't create an empty JPG
 					if ( $jpg_size > $opt_jpg_size && $opt_jpg_size != 0 ) {
 						// replace the original with the optimized file
@@ -2159,7 +2104,6 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 		default:
 			// if not a JPG, PNG, or GIF, tell the user we don't work with strangers
 			return array( false, __( 'Unsupported file type', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . ": $type", $converted, $original );
-//			return array( false, __( 'Unsupported type: ' . $type, EWWW_IMAGE_OPTIMIZER_DOMAIN ), $converted, $original );
 	}
 	// allow other plugins to run operations on the images after optimization.
 	// NOTE: it is recommended to do any image modifications prior to optimization, otherwise you risk un-optimizing your images here.

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -72,8 +72,6 @@ function ewww_image_optimizer_exec_init() {
 				update_site_option( 'ewww_image_optimizer_optipng_level', (int) $_POST['ewww_image_optimizer_optipng_level'] );
 				update_site_option( 'ewww_image_optimizer_pngout_level', (int) $_POST['ewww_image_optimizer_pngout_level'] );
 			}
-//			if (empty($_POST['ewww_image_optimizer_disable_optipng'])) $_POST['ewww_image_optimizer_disable_optipng'] = '';
-//			update_site_option('ewww_image_optimizer_disable_optipng', $_POST['ewww_image_optimizer_disable_optipng']);
 			if ( empty( $_POST['ewww_image_optimizer_disable_pngout'] ) ) {
 				update_site_option( 'ewww_image_optimizer_disable_pngout', false );
 			} else {
@@ -85,7 +83,6 @@ function ewww_image_optimizer_exec_init() {
 	register_setting('ewww_image_optimizer_options', 'ewww_image_optimizer_skip_bundle', 'boolval');
 	register_setting('ewww_image_optimizer_options', 'ewww_image_optimizer_optipng_level', 'intval');
 	register_setting('ewww_image_optimizer_options', 'ewww_image_optimizer_pngout_level', 'intval');
-	register_setting('ewww_image_optimizer_options', 'ewww_image_optimizer_disable_optipng', 'boolval');
 	register_setting('ewww_image_optimizer_options', 'ewww_image_optimizer_disable_pngout', 'boolval');
 	if ( defined( 'WPE_PLUGIN_VERSION' ) ) {
 		add_action( 'network_admin_notices', 'ewww_image_optimizer_notice_wpengine' );
@@ -434,7 +431,7 @@ function ewww_image_optimizer_skip_tools() {
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) == 0 || ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) > 10 ) {
 		$skip['jpegtran'] = true;
 	}
-	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_optipng' ) || ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) == 0 || ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) > 10 ) ) {
+	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) == 0 || ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) > 10 ) ) {
 		$skip['optipng'] = true;
 	}
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ) == 0 || ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
@@ -1574,7 +1571,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 					}
 				}
 				// if optipng isn't disabled
-				if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_optipng' ) ) {
+				if ( $tools['OPTIPNG'] ) {
 					// retrieve the optipng optimization level
 					$optipng_level = (int) ewww_image_optimizer_get_option('ewww_image_optimizer_optipng_level');
 					if (ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpegtran_copy' ) && preg_match( '/0.7/', ewww_image_optimizer_tool_found( $tools['OPTIPNG'], 'o' ) ) && ! $keep_metadata ) {
@@ -1720,7 +1717,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 				);
 			}
 			// if pngout and optipng are disabled
-			if ( ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_optipng' ) && ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_pngout' ) ) || ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) == 0 ) {
+			if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) == 0 ) {
 				// tell the user all PNG tools are disabled
 				$result = __( 'PNG optimization is disabled', EWWW_IMAGE_OPTIMIZER_DOMAIN );
 			// if the utility checking is on, optipng is enabled, but optipng cannot be found
@@ -1755,7 +1752,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 				$tempfile = $file . '.tmp.png';
 				copy( $file, $tempfile );
 				// if optipng is enabled
-				if( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_optipng' ) ) {
+				if( $tools['OPTIPNG'] ) {
 					// retrieve the optimization level for optipng
 					$optipng_level = (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_optipng_level' );
 					if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpegtran_copy' ) && preg_match( '/0.7/', ewww_image_optimizer_tool_found( $tools['OPTIPNG'], 'o' ) ) && ! $keep_metadata ) {
@@ -2040,7 +2037,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 					$new_size = $orig_size;
 				}
 				// if optipng is enabled
-				if ( ! ewww_image_optimizer_get_option('ewww_image_optimizer_disable_optipng') && $tools['OPTIPNG']) {
+				if ( $tools['OPTIPNG'] ) {
 					// retrieve the optipng optimization level
 					$optipng_level = (int) ewww_image_optimizer_get_option('ewww_image_optimizer_optipng_level');
 					if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpegtran_copy' ) && preg_match( '/0.7/', ewww_image_optimizer_tool_found( $tools['OPTIPNG'], 'o' ) ) && ! $keep_metadata ) {

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -15,7 +15,6 @@ Author URI: https://ewww.io/
 License: GPLv3
 */
 
-// TODO: make sure all resizes are converted, only use an increment if there is a conflict
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -456,6 +455,25 @@ function ewww_image_optimizer_skip_tools() {
 		}
 	}
 	return $skip;
+}
+
+function ewww_image_optimizer_define_noexec() {
+	if ( defined( 'EWWW_IMAGE_OPTIMIZER_NOEXEC' ) ) {
+		return;
+	}
+	// Check if exec is disabled
+	if( ewww_image_optimizer_exec_check() ) {
+		define( 'EWWW_IMAGE_OPTIMIZER_NOEXEC', true );
+		ewwwio_debug_message( 'exec seems to be disabled' );
+		ewww_image_optimizer_disable_tools();
+		// otherwise, query the php settings for safe mode
+	} elseif ( ewww_image_optimizer_safemode_check() ) {
+		define( 'EWWW_IMAGE_OPTIMIZER_NOEXEC', true );
+		ewwwio_debug_message( 'safe mode appears to be enabled' );
+		ewww_image_optimizer_disable_tools();
+	} else {
+		define( 'EWWW_IMAGE_OPTIMIZER_NOEXEC', false );
+	}
 }
 
 // we check for safe mode and exec, then also direct the user where to go if they don't have the tools installed
@@ -1306,22 +1324,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 		return array( false, __( 'Unsupported file type', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . ": $type", $converted, $original );
 	}
 	if ( ! EWWW_IMAGE_OPTIMIZER_CLOUD ) {
-		if ( ! defined( 'EWWW_IMAGE_OPTIMIZER_NOEXEC' ) ) {
-			// TODO: this ought to be in a function that we can call
-			// Check if exec is disabled
-			if( ewww_image_optimizer_exec_check() ) {
-				define( 'EWWW_IMAGE_OPTIMIZER_NOEXEC', true );
-				ewwwio_debug_message( 'exec seems to be disabled' );
-				ewww_image_optimizer_disable_tools();
-				// otherwise, query the php settings for safe mode
-			} elseif ( ewww_image_optimizer_safemode_check() ) {
-				define( 'EWWW_IMAGE_OPTIMIZER_NOEXEC', true );
-				ewwwio_debug_message( 'safe mode appears to be enabled' );
-				ewww_image_optimizer_disable_tools();
-			} else {
-				define( 'EWWW_IMAGE_OPTIMIZER_NOEXEC', false );
-			}
-		}
+		ewww_image_optimizer_define_noexec();
 		if ( EWWW_IMAGE_OPTIMIZER_NOEXEC ) {
 			$nice = '';
 		} else {

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -1280,8 +1280,9 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 		// send back the above message
 		return array( false, $msg, $converted, $original );
 	}
-	if ( function_exists( 'fileperms' ) )
+	if ( function_exists( 'fileperms' ) ) {
 		$file_perms = substr( sprintf( '%o', fileperms( $file ) ), -4 );
+	}
 	$file_owner = 'unknown';
 	$file_group = 'unknown';
 	if (function_exists('posix_getpwuid')) {
@@ -1306,6 +1307,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 	}
 	if ( ! EWWW_IMAGE_OPTIMIZER_CLOUD ) {
 		if ( ! defined( 'EWWW_IMAGE_OPTIMIZER_NOEXEC' ) ) {
+			// TODO: this ought to be in a function that we can call
 			// Check if exec is disabled
 			if( ewww_image_optimizer_exec_check() ) {
 				define( 'EWWW_IMAGE_OPTIMIZER_NOEXEC', true );
@@ -1384,8 +1386,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 		// tell the user optimization was skipped
 		return array( false, __( "Optimization skipped", EWWW_IMAGE_OPTIMIZER_DOMAIN ), $converted, $file );
 	}
-	// initialize $new_size with the original size, HOW ABOUT A ZERO...
-	//$new_size = $orig_size;
+	// initialize $new_size with a zero
 	$new_size = 0;
 	// set the optimization process to OFF
 	$optimize = false;

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -2174,7 +2174,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 		$perms = $stat['mode'] & 0000666; //same permissions as parent folder, strip off the executable bits
 		@chmod( $file, $perms );
 
-		$results_msg = ewww_image_optimizer_update_table( $file, $new_size, $orig_size, $new );
+		$results_msg = ewww_image_optimizer_update_table( $file, $new_size, $orig_size, $original );
 		ewwwio_memory( __FUNCTION__ );
 		return array( $file, $results_msg, $converted, $original );
 	}

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -15,6 +15,7 @@ Author URI: https://ewww.io/
 License: GPLv3
 */
 
+// TODO: make sure all resizes are converted, only use an increment if there is a conflict
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -37,6 +38,7 @@ define( 'EWWW_IMAGE_OPTIMIZER_IMAGES_PATH', plugin_dir_path( __FILE__ ) . 'image
 
 require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'common.php' );
 require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'background.php' );
+require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'classes/ewww-image.php' );
 
 // Hooks
 add_action( 'admin_action_ewww_image_optimizer_install_pngout', 'ewww_image_optimizer_install_pngout' );
@@ -1353,17 +1355,17 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 		ewwwio_debug_message( 'full-size image was converted, need to rebuild filename for meta' );
 		$filenum = $converted;
 		// grab the file extension
-		preg_match('/\.\w+$/', $file, $fileext);
+		preg_match( '/\.\w+$/', $file, $fileext );
 		// strip the file extension
-		$filename = str_replace($fileext[0], '', $file);
+		$filename = str_replace( $fileext[0], '', $file );
 		// grab the dimensions
-		preg_match('/-\d+x\d+(-\d+)*$/', $filename, $fileresize);
+		preg_match( '/-\d+x\d+(-\d+)*$/', $filename, $fileresize );
 		// strip the dimensions
-		$filename = str_replace($fileresize[0], '', $filename);
+		$filename = str_replace( $fileresize[0], '', $filename );
 		// reconstruct the filename with the same increment (stored in $converted) as the full version
 		$refile = $filename . '-' . $filenum . $fileresize[0] . $fileext[0];
 		// rename the file
-		rename($file, $refile);
+		rename( $file, $refile );
 		ewwwio_debug_message( "moved $file to $refile" );
 		// and set $file to the new filename
 		$file = $refile;

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -902,11 +902,11 @@ function ewww_image_optimizer_mimetype( $path, $case ) {
 		ewwwio_debug_message( "finfo_file: $type" );
 	}
 	// see if we can use the getimagesize function
-	if ( empty( $type ) && function_exists( 'getimagesize' ) && $case === 'i' ) {
+	if ( empty( $type ) && function_exists( 'getimagesize' ) && $case === 'i' && strpos( ewww_image_optimizer_quick_mimetype( $path ), 'pdf' ) === false ) {
 		// run getimagesize on the file
-		$type = getimagesize($path);
+		$type = getimagesize( $path );
 		// make sure we have results
-		if(false !== $type){
+		if( false !== $type ){
 			// store the mime-type
 			$type = $type['mime'];
 		}

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Integrate image optimizers into WordPress.
- * @version 3.1.3
+ * @version 3.1.9
  * @package EWWW_Image_Optimizer
  */
 /*
@@ -10,7 +10,7 @@ Plugin URI: https://wordpress.org/extend/plugins/ewww-image-optimizer/
 Description: Reduce file sizes for images within WordPress including NextGEN Gallery and GRAND FlAGallery. Uses jpegtran, optipng/pngout, and gifsicle.
 Author: Shane Bishop
 Text Domain: ewww-image-optimizer
-Version: 3.1.3
+Version: 3.1.9
 Author URI: https://ewww.io/
 License: GPLv3
 */

--- a/flag-integration.php
+++ b/flag-integration.php
@@ -15,7 +15,7 @@ class ewwwflag {
 			add_action('flag_manage_post_processor_images', array(&$this, 'ewww_flag_bulk'));
 			add_action('flag_manage_post_processor_galleries', array(&$this, 'ewww_flag_bulk'));
 		}
-		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_background_optimization' ) ) {
+		if ( ewww_image_optimizer_test_background_opt() ) {
 			add_action( 'flag_image_optimized', array( $this, 'queue_new_image' ) );
 			add_action( 'flag_image_resized', array( $this, 'queue_new_image' ) );
 		} else {
@@ -448,6 +448,7 @@ class ewwwflag {
 		$elapsed = microtime( true ) - $started;
 		// and output it to the user
 		$output['results'] .= sprintf( esc_html__( 'Elapsed: %.3f seconds', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . "</p>", $elapsed );
+		$output['completed'] = 1;
 		// send the list back to the db
 		update_option( 'ewww_image_optimizer_bulk_flag_attachments', $attachments, false );
                 if ( ! empty( $attachments ) ) {
@@ -459,9 +460,10 @@ class ewwwflag {
                         } else {
                                 $output['next_file'] =  "<p>" . esc_html__('Optimizing', EWWW_IMAGE_OPTIMIZER_DOMAIN) . "&nbsp;<img src='$loading_image' alt='loading'/></p>";
                         }
-                }
-                echo json_encode( $output );
-		die();
+                } else {
+			$output['done'] = 1;
+		}
+                die( json_encode( $output ) );
 	}
 
 	/* finish the bulk operation, and clear out the bulk_flag options */

--- a/includes/eio.js
+++ b/includes/eio.js
@@ -183,7 +183,7 @@ jQuery(document).ready(function($) {
 					$('#ewww-nothing').show();
 				}
 				else {
-				//	ewwwStartOpt();
+					ewwwStartOpt();
 				}
 			}
 	        })
@@ -353,8 +353,8 @@ jQuery(document).ready(function($) {
 			ewww_force: ewww_force,
 	        };
 	        var ewww_jqxhr = $.post(ajaxurl, ewww_loop_data, function(response) {
-			ewww_i++;
 			var ewww_response = $.parseJSON(response);
+			ewww_i += ewww_response.completed;
 			$('#ewww-bulk-progressbar').progressbar( "option", "value", ewww_i );
 			$('#ewww-bulk-counter').html(ewww_vars.optimized + ' ' + ewww_i + '/' + ewww_attachments);
 			if ( ewww_response.error ) {
@@ -387,7 +387,7 @@ jQuery(document).ready(function($) {
 					ewww_vars._wpnonce = ewww_response.new_nonce;
 				}
 				ewww_error_counter = 30;
-				setTimeout(ewwwProcessImage, ewww_delay * 1000);
+			//	setTimeout(ewwwProcessImage, ewww_delay * 1000); TODO - this is temporarily disabled to stop after the first image
 			}
 			else {
 				if ( ewww_response.results ) {

--- a/includes/eio.js
+++ b/includes/eio.js
@@ -83,6 +83,7 @@ jQuery(document).ready(function($) {
 	var ewww_import_total = 0;
 	var ewww_force = 0;
 	var ewww_delay = 0;
+	var ewww_batch_limit = 0;
 	var ewww_aux = false;
 	var ewww_main = false;
 	var ewww_quota_update = 0;
@@ -140,7 +141,7 @@ jQuery(document).ready(function($) {
 	var ewww_table_count_action = 'bulk_aux_images_table_count';
 	var ewww_import_init_action = 'bulk_import_init';
 	var ewww_import_loop_action = 'bulk_import_loop';
-	$('#ewww-aux-start').submit(function() {
+	$('#ewww-bulk-start').submit(function() {
 		ewww_aux = true;
 		//ewww_init_action = 'bulk_init';
 		//ewww_loop_action = 'bulk_aux_images_loop';
@@ -148,7 +149,7 @@ jQuery(document).ready(function($) {
 		if ($('#ewww-force:checkbox:checked').val()) {
 			ewww_force = 1;
 		}
-		$('#ewww-aux-start').hide();
+		$('#ewww-bulk-start').hide();
 		$('#ewww-scanning').show();
 		ewwwStartScan();
 		return false;
@@ -189,6 +190,7 @@ jQuery(document).ready(function($) {
 			} else if ( ewww_response.ready ) {
 				ewww_attachments = ewww_response.ready;
 				if (ewww_attachments == 0) {
+					$('#ewww-bulk-loading').hide();
 					$('#ewww-scanning').hide();
 					$('#ewww-nothing').show();
 				}
@@ -312,10 +314,10 @@ jQuery(document).ready(function($) {
 		$('.last-page').show();
 		return false;
 	});
-	$('#ewww-bulk-start').submit(function() {
+/*	$('#ewww-bulk-start').submit(function() {
 		ewwwStartOpt();
 		return false;
-	});
+	});*/
 	}
 	function ewwwUpdateQuota() {
 		ewww_quota_update_data.ewww_wpnonce = ewww_vars._wpnonce;
@@ -335,6 +337,10 @@ jQuery(document).ready(function($) {
 			ewww_delay = 0;
 		} else {
 			ewww_delay = $('#ewww-delay').val();
+		}
+		if (ewww_delay) {
+			ewww_batch_limit = 1;
+			$('#ewww-bulk-last h2').html( ewww_vars.last_image_header );
 		}
 		$('.ewww-aux-table').hide();
 		$('#ewww-bulk-stop').show();
@@ -371,6 +377,7 @@ jQuery(document).ready(function($) {
 	                action: ewww_loop_action,
 			ewww_wpnonce: ewww_vars._wpnonce,
 			ewww_force: ewww_force,
+			ewww_batch_limit: ewww_batch_limit,
 	        };
 	        var ewww_jqxhr = $.post(ajaxurl, ewww_loop_data, function(response) {
 			var is_json = true;
@@ -401,7 +408,7 @@ jQuery(document).ready(function($) {
 			else if ( response == 0 ) {
 				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_vars.operation_stopped + '</b></p>');
 			}
-			else if (ewww_i < ewww_attachments) {
+			else if (ewww_i < ewww_attachments && ! ewww_response.done) {
 				$('#ewww-bulk-widgets').show();
 				$('#ewww-bulk-status h2').show();
 				$('#ewww-bulk-last h2').show();
@@ -416,7 +423,7 @@ jQuery(document).ready(function($) {
 					ewww_vars._wpnonce = ewww_response.new_nonce;
 				}
 				ewww_error_counter = 30;
-				setTimeout(ewwwProcessImage, ewww_delay * 1000); // TODO - this is temporarily disabled to stop after the first image
+				setTimeout(ewwwProcessImage, ewww_delay * 1000);
 			}
 			else {
 				if ( ewww_response.results ) {

--- a/includes/eio.js
+++ b/includes/eio.js
@@ -126,7 +126,7 @@ jQuery(document).ready(function($) {
 			});
 		}
 	} else {
-		var ewww_scan_action = 'bulk_aux_images_scan';
+		var ewww_scan_action = 'bulk_scan';
 		var ewww_init_action = 'bulk_init';
 		var ewww_loop_action = 'bulk_loop';
 		var ewww_cleanup_action = 'bulk_cleanup';
@@ -142,9 +142,9 @@ jQuery(document).ready(function($) {
 	var ewww_import_loop_action = 'bulk_import_loop';
 	$('#ewww-aux-start').submit(function() {
 		ewww_aux = true;
-		ewww_init_action = 'bulk_aux_images_init';
-		ewww_loop_action = 'bulk_aux_images_loop';
-		ewww_cleanup_action = 'bulk_aux_images_cleanup';
+		//ewww_init_action = 'bulk_init';
+		//ewww_loop_action = 'bulk_aux_images_loop';
+		//ewww_cleanup_action = 'bulk_aux_images_cleanup';
 		if ($('#ewww-force:checkbox:checked').val()) {
 			ewww_force = 1;
 		}
@@ -158,19 +158,33 @@ jQuery(document).ready(function($) {
 			action: ewww_scan_action,
 			ewww_force: ewww_force,
 			ewww_scan: true,
+			ewww_wpnonce: ewww_vars._wpnonce,
 		};
 		$.post(ajaxurl, ewww_scan_data, function(response) {
-			ewww_attachments = response;
+			ewww_response = $.parseJSON(response);
 			ewww_init_data = {
 			        action: ewww_init_action,
 				ewww_wpnonce: ewww_vars._wpnonce,
 			};
-			if (ewww_attachments == 0) {
-				$('#ewww-scanning').hide();
-				$('#ewww-nothing').show();
-			}
-			else {
-				ewwwStartOpt();
+			if ( ewww_response.error ) {
+				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_response.error + '</b></p>');
+			} else if ( ewww_response.remaining ) {
+				$('.ewww-aux-table').hide();
+				//$('#ewww-bulk-stop').show();
+				$('.ewww-bulk-form').hide();
+				$('.ewww-bulk-info').hide();
+				$('h2').hide();	
+				$('#ewww-bulk-loading').html( ewww_response.remaining );
+				ewwwStartScan();
+			} else if ( ewww_response.ready ) {
+				ewww_attachments = ewww_response.ready;
+				if (ewww_attachments == 0) {
+					$('#ewww-scanning').hide();
+					$('#ewww-nothing').show();
+				}
+				else {
+				//	ewwwStartOpt();
+				}
 			}
 	        })
 		.fail(function() { 

--- a/includes/eio.js
+++ b/includes/eio.js
@@ -154,7 +154,7 @@ jQuery(document).ready(function($) {
 		$('.ewww-aux-table').hide();
 		$('#ewww-show-table').hide();
 		$('#ewww-scanning').show();
-		ewww_vars.scanning = $('#ewww-scanning').html(); // TODO: use this to reset the scan text
+		//ewww_vars.scanning = $('#ewww-scanning').html();
 		ewwwStartScan();
 		return false;
 	});
@@ -173,7 +173,7 @@ jQuery(document).ready(function($) {
 				is_json = false;
 			}
 			if ( ! is_json ) {
-				$('#ewww-scanning').html('<p style="color: red"><b>' + ewww_vars.invalid_response + '</b></p>');
+				$('#ewww-scanning').html('<span style="color: red"><b>' + ewww_vars.invalid_response + '</b></span>');
 				return false;
 			}	
 			//ewww_response = $.parseJSON(response);
@@ -182,7 +182,7 @@ jQuery(document).ready(function($) {
 				ewww_wpnonce: ewww_vars._wpnonce,
 			};
 			if ( ewww_response.error ) {
-				$('#ewww-scanning').html('<p style="color: red"><b>' + ewww_response.error + '</b></p>');
+				$('#ewww-scanning').html('<span style="color: red"><b>' + ewww_response.error + '</b></span>');
 			} else if ( ewww_response.remaining ) {
 				$('.ewww-aux-table').hide();
 				$('#ewww-show-table').hide();
@@ -211,9 +211,9 @@ jQuery(document).ready(function($) {
 		.fail(function() { 
 			ewww_scan_failures++;
 			if (ewww_scan_failures > 10) {
-				$('#ewww-scanning').html('<p style="color: red"><b>' + ewww_vars.scan_fail + '</b></p>');
+				$('#ewww-scanning').html('<span style="color: red"><b>' + ewww_vars.scan_fail + '</b></span>');
 			} else {
-				$('#ewww-scanning').html('<p style="color: red"><b>' + ewww_vars.scan_incomplete + '</b></p>');
+				$('#ewww-scanning').html('<span style="color: red"><b>' + ewww_vars.scan_incomplete + '</b></span>');
 				setTimeout(function() {
 					ewwwStartScan();
 				}, 1000);
@@ -355,7 +355,10 @@ jQuery(document).ready(function($) {
 		$('#ewww-bulk-stop').show();
 		$('.ewww-bulk-form').hide();
 		$('.ewww-bulk-info').hide();
-		$('h2').hide();	
+		$('h2').hide();
+//		if ( ewww_vars.scanning ) {
+//			$('#ewww-scanning').html( ewww_vars.scanning );
+//		}
 	        $.post(ajaxurl, ewww_init_data, function(response) {
 			var is_json = true;
 			try {
@@ -436,9 +439,8 @@ jQuery(document).ready(function($) {
 			}
 			else {
 				if ( ewww_response.results ) {
-				$('#ewww-bulk-widgets').show();
-				$('#ewww-bulk-status h2').show();
-				//$('#ewww-bulk-last h2').show();
+					$('#ewww-bulk-widgets').show();
+					$('#ewww-bulk-status h2').show();
 		                	$('#ewww-bulk-status .inside').append( ewww_response.results );
 				}
 				clearInterval(ewww_quota_update);
@@ -477,15 +479,15 @@ jQuery(document).ready(function($) {
 			});
 			$('#ewww-show-table').show();
 			$('#ewww-table-info').show();
-			$('#ewww-lastaux').show();
-			$('#ewww-aux-forms .ewww-aux-info').show();
-			$('#ewww-aux-start').show();
-			$('#ewww-aux-reset-desc').show();
+			//$('#ewww-lastaux').show();
+			//$('#ewww-aux-forms .ewww-aux-info').show();
+			//$('#ewww-aux-start').show();
+			//$('#ewww-aux-reset-desc').show();
 			//$('.ewww-media-info').show();
-			$('h2.ewww-bulk-aux').show();
+			//$('h2.ewww-bulk-aux').show();
 			if (ewww_aux == true) {
 				$('#ewww-aux-first').hide();
-				$('#ewww-aux-again').show();
+				//$('#ewww-aux-again').show();
 			} else {
 				$('#ewww-bulk-first').hide();
 			//	$('#ewww-bulk-again').show();

--- a/includes/eio.js
+++ b/includes/eio.js
@@ -141,7 +141,7 @@ jQuery(document).ready(function($) {
 	var ewww_table_count_action = 'bulk_aux_images_table_count';
 	var ewww_import_init_action = 'bulk_import_init';
 	var ewww_import_loop_action = 'bulk_import_loop';
-	$('#ewww-bulk-start').submit(function() {
+	$('#ewww-aux-start').submit(function() {
 		ewww_aux = true;
 		//ewww_init_action = 'bulk_init';
 		//ewww_loop_action = 'bulk_aux_images_loop';
@@ -149,8 +149,12 @@ jQuery(document).ready(function($) {
 		if ($('#ewww-force:checkbox:checked').val()) {
 			ewww_force = 1;
 		}
-		$('#ewww-bulk-start').hide();
+		$('#ewww-aux-start').hide();
+		$('.ewww-bulk-info').hide();
+		$('.ewww-aux-table').hide();
+		$('#ewww-show-table').hide();
 		$('#ewww-scanning').show();
+		ewww_vars.scanning = $('#ewww-scanning').html(); // TODO: use this to reset the scan text
 		ewwwStartScan();
 		return false;
 	});
@@ -169,7 +173,7 @@ jQuery(document).ready(function($) {
 				is_json = false;
 			}
 			if ( ! is_json ) {
-				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_vars.invalid_response + '</b></p>');
+				$('#ewww-scanning').html('<p style="color: red"><b>' + ewww_vars.invalid_response + '</b></p>');
 				return false;
 			}	
 			//ewww_response = $.parseJSON(response);
@@ -178,24 +182,29 @@ jQuery(document).ready(function($) {
 				ewww_wpnonce: ewww_vars._wpnonce,
 			};
 			if ( ewww_response.error ) {
-				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_response.error + '</b></p>');
+				$('#ewww-scanning').html('<p style="color: red"><b>' + ewww_response.error + '</b></p>');
 			} else if ( ewww_response.remaining ) {
 				$('.ewww-aux-table').hide();
-				//$('#ewww-bulk-stop').show();
-				$('.ewww-bulk-form').hide();
-				$('.ewww-bulk-info').hide();
-				$('h2').hide();	
-				$('#ewww-bulk-loading').html( ewww_response.remaining );
+				$('#ewww-show-table').hide();
+				//$('.ewww-bulk-form').hide();
+				//$('.ewww-bulk-info').hide();
+				//$('h2').hide();	
+				$('#ewww-scanning').html( ewww_response.remaining );
 				ewwwStartScan();
 			} else if ( ewww_response.ready ) {
 				ewww_attachments = ewww_response.ready;
 				if (ewww_attachments == 0) {
-					$('#ewww-bulk-loading').hide();
+				//	$('#ewww-bulk-loading').hide();
 					$('#ewww-scanning').hide();
 					$('#ewww-nothing').show();
+					//$('#ewww-aux-start').show();
+					//$('#ewww-aux-again').show();
+					//$('#ewww-aux-first').hide();
 				}
 				else {
-					ewwwStartOpt();
+					$('#ewww-scanning').html(ewww_response.message);
+					$('#ewww-bulk-start').show();
+//					ewwwStartOpt();
 				}
 			}
 	        })
@@ -314,10 +323,10 @@ jQuery(document).ready(function($) {
 		$('.last-page').show();
 		return false;
 	});
-/*	$('#ewww-bulk-start').submit(function() {
+	$('#ewww-bulk-start').submit(function() {
 		ewwwStartOpt();
 		return false;
-	});*/
+	});
 	}
 	function ewwwUpdateQuota() {
 		ewww_quota_update_data.ewww_wpnonce = ewww_vars._wpnonce;

--- a/includes/eio.js
+++ b/includes/eio.js
@@ -161,7 +161,17 @@ jQuery(document).ready(function($) {
 			ewww_wpnonce: ewww_vars._wpnonce,
 		};
 		$.post(ajaxurl, ewww_scan_data, function(response) {
-			ewww_response = $.parseJSON(response);
+			var is_json = true;
+			try {
+				var ewww_response = $.parseJSON(response);
+			} catch (err) {
+				is_json = false;
+			}
+			if ( ! is_json ) {
+				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_vars.invalid_response + '</b></p>');
+				return false;
+			}	
+			//ewww_response = $.parseJSON(response);
 			ewww_init_data = {
 			        action: ewww_init_action,
 				ewww_wpnonce: ewww_vars._wpnonce,
@@ -332,7 +342,17 @@ jQuery(document).ready(function($) {
 		$('.ewww-bulk-info').hide();
 		$('h2').hide();	
 	        $.post(ajaxurl, ewww_init_data, function(response) {
-			var ewww_init_response = $.parseJSON(response);
+			var is_json = true;
+			try {
+				var ewww_init_response = $.parseJSON(response);
+			} catch (err) {
+				is_json = false;
+			}
+			if ( ! is_json ) {
+				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_vars.invalid_response + '</b></p>');
+				return false;
+			}	
+			//var ewww_init_response = $.parseJSON(response);
 			if ( ewww_init_response.error ) {
 				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_init_response.error + '</b></p>');
 			} else {
@@ -353,7 +373,16 @@ jQuery(document).ready(function($) {
 			ewww_force: ewww_force,
 	        };
 	        var ewww_jqxhr = $.post(ajaxurl, ewww_loop_data, function(response) {
-			var ewww_response = $.parseJSON(response);
+			var is_json = true;
+			try {
+				var ewww_response = $.parseJSON(response);
+			} catch (err) {
+				is_json = false;
+			}
+			if ( ! is_json ) {
+				$('#ewww-bulk-loading').html('<p style="color: red"><b>' + ewww_vars.invalid_response + '</b></p>');
+				return false;
+			}	
 			ewww_i += ewww_response.completed;
 			$('#ewww-bulk-progressbar').progressbar( "option", "value", ewww_i );
 			$('#ewww-bulk-counter').html(ewww_vars.optimized + ' ' + ewww_i + '/' + ewww_attachments);
@@ -387,7 +416,7 @@ jQuery(document).ready(function($) {
 					ewww_vars._wpnonce = ewww_response.new_nonce;
 				}
 				ewww_error_counter = 30;
-			//	setTimeout(ewwwProcessImage, ewww_delay * 1000); TODO - this is temporarily disabled to stop after the first image
+				setTimeout(ewwwProcessImage, ewww_delay * 1000); // TODO - this is temporarily disabled to stop after the first image
 			}
 			else {
 				if ( ewww_response.results ) {

--- a/nextcellent-integration.php
+++ b/nextcellent-integration.php
@@ -500,6 +500,7 @@ class ewwwngg {
 		// outupt how much time we spent
 		$elapsed = microtime( true ) - $started;
 		$output['results'] .= sprintf( esc_html__( 'Elapsed: %.3f seconds', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . "</p>", $elapsed);
+		$output['completed'] = 1;
 		//store the list back in the db
 		update_option( 'ewww_image_optimizer_bulk_ngg_attachments', $attachments, false );
 		if ( ! empty( $attachments ) ) {
@@ -511,9 +512,10 @@ class ewwwngg {
                         } else {
                                 $output['next_file'] =  "<p>" . esc_html__('Optimizing', EWWW_IMAGE_OPTIMIZER_DOMAIN) . "&nbsp;<img src='$loading_image' alt='loading'/></p>";
                         }
-                }
-                echo json_encode( $output );
-		die();
+                } else {
+			$output['done'] = 1;
+		}
+                die( json_encode( $output ) );
 	}
 
 	/* finish the bulk operation */

--- a/nextgen2-integration.php
+++ b/nextgen2-integration.php
@@ -125,7 +125,8 @@ class ewwwngg {
 		$storage  = $registry->get_utility( 'I_Gallery_Storage' );
 		$filename = $storage->get_image_abspath( $image, $size );
 		if ( file_exists( $filename ) ) {
-			if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_debug' ) ) {
+			// TODO: shouldn't we actually test for background option or use the background tester function?
+			if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_debug' ) ) {
 				ewww_image_optimizer( $filename, 2 );
 				ewwwio_debug_message( "nextgen dynamic thumb saved: $filename" );
 				$image_size = ewww_image_optimizer_filesize( $filename );

--- a/nextgen2-integration.php
+++ b/nextgen2-integration.php
@@ -11,7 +11,7 @@ class ewwwngg {
 		add_filter( 'ngg_manage_images_number_of_columns', array( $this, 'ewww_manage_images_number_of_columns' ) );
 		add_filter( 'ngg_manage_images_row_actions', array( $this, 'ewww_manage_images_row_actions' ) );
 		add_action( 'ngg_manage_image_custom_column', array( $this, 'ewww_manage_image_custom_column' ), 10, 2 );
-		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_background_optimization' ) ) {
+		if ( ewww_image_optimizer_test_background_opt() ) {
 			add_action( 'ngg_added_new_image', array( $this, 'queue_new_image' ) );
 		} else {
 			add_action( 'ngg_added_new_image', array( $this, 'ewww_added_new_image' ) );
@@ -38,7 +38,7 @@ class ewwwngg {
 		if ( ! defined( 'NGGFOLDER' ) ) {
 			return;
 		}
-		add_submenu_page(NGGFOLDER, esc_html__('Bulk Optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN), esc_html__('Bulk Optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN), apply_filters( 'ewww_image_optimizer_manual_permissions', '' ), 'ewww-ngg-bulk', array (&$this, 'ewww_ngg_bulk_preview'));
+		add_submenu_page( NGGFOLDER, esc_html__( 'Bulk Optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN ), esc_html__( 'Bulk Optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN ), apply_filters( 'ewww_image_optimizer_manual_permissions', '' ), 'ewww-ngg-bulk', array ( &$this, 'ewww_ngg_bulk_preview' ) );
 	}
 	function queue_new_image( $image, $storage = null ) {
 		ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
@@ -125,24 +125,10 @@ class ewwwngg {
 		$storage  = $registry->get_utility( 'I_Gallery_Storage' );
 		$filename = $storage->get_image_abspath( $image, $size );
 		if ( file_exists( $filename ) ) {
-			// TODO: shouldn't we actually test for background option or use the background tester function?
-			if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_debug' ) ) {
-				ewww_image_optimizer( $filename, 2 );
-				ewwwio_debug_message( "nextgen dynamic thumb saved: $filename" );
-				$image_size = ewww_image_optimizer_filesize( $filename );
-				ewwwio_debug_message( "optimized size: $image_size" );
-			} else {
-				global $ewwwio_image_background;
-				if ( ! class_exists( 'WP_Background_Process' ) ) {
-					require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'background.php' );
-				}
-				if ( ! is_object( $ewwwio_image_background ) ) {
-					$ewwwio_image_background = new EWWWIO_Image_Background_Process();
-				}
-				$ewwwio_image_background->push_to_queue( $filename );
-				$ewwwio_image_background->save()->dispatch();
-				ewwwio_debug_message( "nextgen dynamic thumb queued: $filename" );
-			}
+			ewww_image_optimizer( $filename, 2 );
+			ewwwio_debug_message( "nextgen dynamic thumb saved: $filename" );
+			$image_size = ewww_image_optimizer_filesize( $filename );
+			ewwwio_debug_message( "optimized size: $image_size" );
 		}
 		ewww_image_optimizer_debug_log();
 	}
@@ -590,6 +576,7 @@ class ewwwngg {
 		// outupt how much time we spent
 		$elapsed = microtime( true ) - $started;
 		$output['results'] .= sprintf( esc_html__( 'Elapsed: %.3f seconds', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . "</p>", $elapsed );
+		$output['completed'] = 1;
 		// store the list back in the db
 		update_option('ewww_image_optimizer_bulk_ngg_attachments', $attachments, false);
 		if ( ! empty( $attachments ) ) {
@@ -601,9 +588,10 @@ class ewwwngg {
 			} else {
 				$output['next_file'] =  "<p>" . esc_html__('Optimizing', EWWW_IMAGE_OPTIMIZER_DOMAIN) . "&nbsp;<img src='$loading_image' alt='loading'/></p>";
 			}
+		} else {
+			$output['done'] = 1;
 		}
-		echo json_encode( $output );
-		die();
+		die( json_encode( $output ) );
 	}
 
 	/* finish the bulk operation */

--- a/readme.txt
+++ b/readme.txt
@@ -261,6 +261,7 @@ Pngout, TinyJPG/TinyPNG, JPEGmini, and Pngquant were recommended by EWWW IO user
 * If you would like to help translate this plugin in your language, get started here: https://translate.wordpress.org/projects/wp-plugins/ewww-image-optimizer/
 
 = 3.2.0 =
+* removed: ability to use the ImageMagick 'convert' binary, use Imagick extension for PHP instead
 * fixed: parallel mode prevents successful conversion
 
 = 3.1.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -260,6 +260,9 @@ Pngout, TinyJPG/TinyPNG, JPEGmini, and Pngquant were recommended by EWWW IO user
 * feature requests are sticky at the top of the support forums, vote for the ones you like: https://wordpress.org/support/plugin/ewww-image-optimizer
 * If you would like to help translate this plugin in your language, get started here: https://translate.wordpress.org/projects/wp-plugins/ewww-image-optimizer/
 
+= 3.2.0 =
+* fixed: parallel mode prevents successful conversion
+
 = 3.1.3 =
 * added: settings which require validation display appropriate errors when validation fails
 * added: filter to make sure test images in the ewww-image-optimizer folder never get optimized


### PR DESCRIPTION
Obviously a huge amount of changes here. Mostly in relation to unifying the bulk optimizer, and removing IO data from the attachment metadata. Conversion has been extended to retina images and the custom resizes that EWWW IO can detect, and conversion has been somewhat decoupled from optimization, although full-size uploads are still optimized/converted at once. The scanning feature works in batches, and can resume while remembering which folders have been scanned (stage 2). Tons of fixes for things I didn't even know were broken, and cleanup of some old code and options.