### PR TITLE
Bulk optimization not working for utf-8 filenames

### DIFF
--- a/aux-optimize.php
+++ b/aux-optimize.php
@@ -41,7 +41,7 @@ function ewww_image_optimizer_aux_images () {
 				<input type="hidden" name="ewww_convert" value="1">
 				<button id="ewww-table-convert" type="submit" class="button-secondary action"><?php esc_html_e( 'Convert Table', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></button>
 			</form>
-		<?php } ?>	
+		<?php } ?>
 		<?php if ( ! empty( $lastaux ) ) { ?>
 	<!--		<p id="ewww-lastaux" class="ewww-bulk-info"><?php printf( esc_html__( 'Last optimization was completed on %1$s at %2$s and optimized %3$d images', EWWW_IMAGE_OPTIMIZER_DOMAIN ), date( get_option( 'date_format' ), $lastaux[0] ), date( get_option( 'time_format' ), $lastaux[0] ), (int) $lastaux[1] ); ?></p>-->
 		<?php } ?>
@@ -62,7 +62,7 @@ function ewww_image_optimizer_aux_images () {
 			<span id="paginator" class="pagination-links ewww-aux-table">
 				<a id="first-images" class="first-page" style="display:none">&laquo;</a>
 				<a id="prev-images" class="prev-page" style="display:none">&lsaquo;</a>
-				<?php esc_html_e( 'page', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?> <span class="current-page"></span> <?php esc_html_e( 'of', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?> 
+				<?php esc_html_e( 'page', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?> <span class="current-page"></span> <?php esc_html_e( 'of', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?>
 				<span class="total-pages"></span>
 				<a id="next-images" class="next-page" style="display:none">&rsaquo;</a>
 				<a id="last-images" class="last-page" style="display:none">&raquo;</a>
@@ -86,7 +86,7 @@ function ewww_image_optimizer_aux_images_table() {
 	// verify that an authorized user has called function
 	if ( ! wp_verify_nonce( $_REQUEST['ewww_wpnonce'], 'ewww-image-optimizer-bulk' ) ) {
 		wp_die( esc_html__( 'Access token has expired, please reload the page.', EWWW_IMAGE_OPTIMIZER_DOMAIN ) );
-	} 
+	}
 	global $wpdb;
 	$offset = 50 * (int) $_POST['ewww_offset'];
 	$query = "SELECT path,results,image_size,id FROM $wpdb->ewwwio_images WHERE pending=0 ORDER BY id DESC LIMIT $offset,50";
@@ -139,7 +139,7 @@ function ewww_image_optimizer_aux_images_remove() {
 	// verify that an authorized user has called function
 	if ( ! wp_verify_nonce( $_REQUEST['ewww_wpnonce'], 'ewww-image-optimizer-bulk' ) ) {
 		wp_die( esc_html__( 'Access token has expired, please reload the page.', EWWW_IMAGE_OPTIMIZER_DOMAIN ) );
-	} 
+	}
 	global $wpdb;
 	if ( $wpdb->delete( $wpdb->ewwwio_images, array( 'id' => $_POST['ewww_image_id'] ) ) ) {
 		echo "1";
@@ -264,7 +264,12 @@ function ewww_image_optimizer_image_scan( $dir, $started = 0 ) {
 			} else {
 				ewwwio_debug_message( "queuing $path" );
 				$image_size = $file->getSize();
-				$images[] = "('" . esc_sql( utf8_encode( $path ) ) . "',$image_size,1)";
+				if ( seems_utf8( $path ) ) {
+					$utf8_file_path = $path;
+				} else {
+					$utf8_file_path = utf8_encode( $path );
+				}
+				$images[] = "('" . esc_sql( $utf8_file_path ) . "',$image_size,1)";
 				$image_count++;
 			}
 			if ( $image_count > 1000 ) {
@@ -371,13 +376,13 @@ function ewww_image_optimizer_aux_images_script( $hook = '' ) {
 		}
 		if ( is_plugin_active( 'ml-slider/ml-slider.php' ) || is_plugin_active_for_network( 'ml-slider/ml-slider.php' ) ) {
 			$slide_paths = array();
-			$slides = $wpdb->get_col( 
+			$slides = $wpdb->get_col(
 				"
-				SELECT wpposts.ID 
-				FROM $wpdb->posts wpposts 
+				SELECT wpposts.ID
+				FROM $wpdb->posts wpposts
 				INNER JOIN $wpdb->term_relationships term_relationships
 						ON wpposts.ID = term_relationships.object_id
-				INNER JOIN $wpdb->terms wpterms 
+				INNER JOIN $wpdb->terms wpterms
 						ON term_relationships.term_taxonomy_id = wpterms.term_id
 				INNER JOIN $wpdb->term_taxonomy term_taxonomy
 						ON wpterms.term_id = term_taxonomy.term_id
@@ -475,7 +480,7 @@ function ewww_image_optimizer_aux_images_initialize( $auto = false ) {
 		wp_die( esc_html__( 'Access denied.', EWWW_IMAGE_OPTIMIZER_DOMAIN ) );
 	}
 	session_write_close();
-	$output = array(); 
+	$output = array();
 	// update the 'aux resume' option to show that an operation is in progress
 	update_option( 'ewww_image_optimizer_aux_resume', 'true' );
 	// store the time and number of images for later display

--- a/bulk.php
+++ b/bulk.php
@@ -7,7 +7,7 @@ function ewww_image_optimizer_bulk_preview() {
 	ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
 	// retrieve the attachment IDs that were pre-loaded in the database
 ?>
-	<div class="wrap"> 
+	<div class="wrap">
 	<h1>
 <?php 		esc_html_e( 'Bulk Optimize', EWWW_IMAGE_OPTIMIZER_DOMAIN );
 		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
@@ -71,12 +71,12 @@ function ewww_image_optimizer_bulk_preview() {
 			echo '<p>' . esc_html__( 'You do not appear to have uploaded any images yet.', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . '</p>';
 		} else { ?>
 			<div id="ewww-bulk-forms">
-<?php			if ( $resume == 'true' ) { 
+<?php			if ( $resume == 'true' ) {
 				//if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
 				//	$credits_needed = $fullsize_count * ( count( get_intermediate_image_sizes() ) + 1 );
 				//} ?>
 				<p class="ewww-media-info ewww-bulk-info"><?php printf( esc_html__( 'There are %d images ready to optimize.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $fullsize_count ); ?> <?php //if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && $credits_needed > 0 ) { printf( esc_html__( 'This could require approximately %d image credits to complete.', EWWW_IMAGE_OPTIMIZER_DOMAIN ), $credits_needed ); } ?></p>
-<?php			} else { 
+<?php			} else {
 				//if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
 				//	$credits_needed = $unoptimized_count + $unoptimized_resize_count;
 				//} ?>
@@ -98,7 +98,7 @@ function ewww_image_optimizer_bulk_preview() {
 			</form>
 <?php		}
 		// if the 'bulk resume' option was not empty, offer to reset it so the user can start back from the beginning
-		if ( $resume == 'true' ) { 
+		if ( $resume == 'true' ) {
 ?>
 			<p class="ewww-media-info ewww-bulk-info"><?php esc_html_e( 'If you would like to start over again, press the Reset Status button to reset the bulk operation status.', EWWW_IMAGE_OPTIMIZER_DOMAIN ); ?></p>
 			<form class="ewww-bulk-form" method="post" action="">
@@ -479,7 +479,7 @@ function ewww_image_optimizer_media_scan( $hook = '' ) {
 	$started = microtime( true );
 
 	ewww_image_optimizer_optimized_list();
-	
+
 	$max_query = apply_filters( 'ewww_image_optimizer_count_optimized_queries', 2000 );
 	$max_query = (int) $max_query;
 
@@ -520,7 +520,7 @@ function ewww_image_optimizer_media_scan( $hook = '' ) {
 		}
 
 		$attachment_meta = ewww_image_optimizer_fetch_metadata_batch( $attachments_in );
-		$attachments_in = null;	
+		$attachments_in = null;
 
 		ewwwio_debug_message( "validated " . count( $attachment_meta ) . " attachment meta items" );
 		ewwwio_debug_message( 'remaining items after selection: ' . count( $attachment_ids ) );
@@ -682,7 +682,7 @@ function ewww_image_optimizer_media_scan( $hook = '' ) {
 					if ( is_file( $imagemeta_resize_path ) ) {
 						$attachment_images[ 'resized-images-' . $index ] = $imagemeta_resize_path;
 					}
-				}		
+				}
 			}
 
 			// and another custom theme
@@ -743,7 +743,12 @@ function ewww_image_optimizer_media_scan( $hook = '' ) {
 					} else {
 						$image_size = filesize( $file_path );
 					}
-					$images[] = "('" . esc_sql( utf8_encode( $file_path ) ) . "','media',$image_size,$selected_id,'$size',1)";
+					if ( seems_utf8( $file_path ) ) {
+						$utf8_file_path = $file_path;
+					} else {
+						$utf8_file_path = utf8_encode( $file_path );
+					}
+					$images[] = "('" . esc_sql( $utf8_file_path ) . "','media',$image_size,$selected_id,'$size',1)";
 					$image_count++;
 				}
 				if ( $image_count > 1000 || count( $reset_images ) > 1000 ) {
@@ -819,7 +824,7 @@ function ewww_image_optimizer_bulk_quota_update() {
 		die( esc_html__( 'Access token has expired, please reload the page.', EWWW_IMAGE_OPTIMIZER_DOMAIN ) );
 	}
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-	//	ewww_image_optimizer_cloud_verify(); 
+	//	ewww_image_optimizer_cloud_verify();
 		echo esc_html__( 'Image credits available:', EWWW_IMAGE_OPTIMIZER_DOMAIN ) . ' ' . ewww_image_optimizer_cloud_quota();
 	}
 	ewwwio_memory( __FUNCTION__ );

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === EWWW Image Optimizer ===
 Contributors: nosilver4u
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MKMQKCBFFG3WW
-Tags: image, compress, optimize, optimization, lossless, lossy, photo, picture, seo, jpegmini, tinyjpg, tinypng, webp, wp-cli 
+Tags: image, compress, optimize, optimization, lossless, lossy, photo, picture, seo, jpegmini, tinyjpg, tinypng, webp, wp-cli
 Requires at least: 4.4
 Tested up to: 4.7.0
 Stable tag: 3.2.1
@@ -39,13 +39,13 @@ The EWWW Image Optimizer is developed at https://github.com/nosilver4u/ewww-imag
 
 = Bulk Optimize =
 
-Optimize all your images from a single page using the Bulk Scanner. This includes the Media Library, your theme, and a handful of pre-configured folders (see Optimize Everything Else below). Officially supported galleries (GRAND FlaGallery, NextCellent and NextGEN) have their own Bulk Optimize pages. 
+Optimize all your images from a single page using the Bulk Scanner. This includes the Media Library, your theme, and a handful of pre-configured folders (see Optimize Everything Else below). Officially supported galleries (GRAND FlaGallery, NextCellent and NextGEN) have their own Bulk Optimize pages.
 
 = Skips Previously Optimized Images =
 
 All optimized images are stored in the database so that the plugin does not attempt to re-optimize them unless they are modified. On the Bulk Optimize page you can view a list of already optimized images. You may also remove individual images from the list, or use the Force optimize option to override the default behavior. The re-optimize links on the Media Library page also force the plugin to ignore the previous optimization status of images.
 
-= WP Image Editor = 
+= WP Image Editor =
 
 All images created by the built-in WP_Image_Editor class will be automatically optimized. Current implementations are GD, Imagick, and Gmagick. Images optimized via this class include Animated GIF Resize, BuddyPress Activity Plus (thumbs), Easy Watermark, Hammy, Imsanity, MediaPress, Meta Slider, MyArcadePlugin, OTF Regenerate Thumbnails, Regenerate Thumbnails, Simple Image Sizes, WP Retina 2x, WP RSS Aggregator and probably countless others. If you are not sure if a plugin uses WP_Image_Editor, send an inquiry on the support page.
 
@@ -59,7 +59,7 @@ Can generate WebP versions of your images, and enables you to serve even smaller
 
 = WP-CLI =
 
-Allows you to run all Bulk Optimization processes from your command line, instead of the web interface. It is much faster, and allows you to do things like run it in 'screen' or via regular cron (instead of wp-cron, which can be unpredictable on low-traffic sites). Install WP-CLI from wp-cli.org, and run 'wp-cli.phar help ewwwio optimize' for more information. 
+Allows you to run all Bulk Optimization processes from your command line, instead of the web interface. It is much faster, and allows you to do things like run it in 'screen' or via regular cron (instead of wp-cron, which can be unpredictable on low-traffic sites). Install WP-CLI from wp-cli.org, and run 'wp-cli.phar help ewwwio optimize' for more information.
 
 = FooGallery =
 
@@ -191,8 +191,8 @@ Using the command *gifsicle -b -O3 --careful original file*. This is particularl
 
 = I want to know more about image optimization, and why you chose these options/tools. =
 
-That's not a question, but since I made it up, I'll answer it. See these resources:  
-http://developer.yahoo.com/performance/rules.html#opt_images  
+That's not a question, but since I made it up, I'll answer it. See these resources:
+http://developer.yahoo.com/performance/rules.html#opt_images
 https://developers.google.com/speed/docs/insights/OptimizeImages
 
 Pngout, TinyJPG/TinyPNG, JPEGmini, and Pngquant were recommended by EWWW IO users. Pngout (usually) optimizes better than Optipng, and best when they are used together. TinyJPG is the best lossy compression tool that I have found for JPG images. Pngquant is an excellent lossy optimizer for PNGs, and is one of the tools used by TinyPNG.
@@ -216,6 +216,7 @@ Pngout, TinyJPG/TinyPNG, JPEGmini, and Pngquant were recommended by EWWW IO user
 * fixed: bulk optimization not playing nice with WP Offload S3
 * fixed: compatibility with WP Retina Pro full-size option when resizing images
 * fixed: optimization results for resized original not displayed when using Imsanity
+* fixed: bulk optimization not working for utf-8 filenames
 * notice: FreeBSD 9 is EOL, version 10.3 is now the currently supported version
 * notice: RHEL 5 and CentOS 5 will be EOL at the end of March, at that point version 6 will be the lowest supported version
 
@@ -272,8 +273,8 @@ Pngout, TinyJPG/TinyPNG, JPEGmini, and Pngquant were recommended by EWWW IO user
 
 == Contact and Credits ==
 
-Written by [Shane Bishop](https://ewww.io). Based upon CW Image Optimizer, which was written by [Jacob Allred](http://www.jacoballred.com/) at [Corban Works, LLC](http://www.corbanworks.com/). CW Image Optimizer was based on WP Smush.it. Jpegtran is the work of the Independent JPEG Group.  
-[Hammer](http://thenounproject.com/noun/hammer/#icon-No1306) designed by [John Caserta](http://thenounproject.com/johncaserta) from The Noun Project.  
+Written by [Shane Bishop](https://ewww.io). Based upon CW Image Optimizer, which was written by [Jacob Allred](http://www.jacoballred.com/) at [Corban Works, LLC](http://www.corbanworks.com/). CW Image Optimizer was based on WP Smush.it. Jpegtran is the work of the Independent JPEG Group.
+[Hammer](http://thenounproject.com/noun/hammer/#icon-No1306) designed by [John Caserta](http://thenounproject.com/johncaserta) from The Noun Project.
 [Images](http://thenounproject.com/noun/images/#icon-No22772) designed by [Simon Henrotte](http://thenounproject.com/Gizmodesbois) from The Noun Project.
 
 = optipng =


### PR DESCRIPTION
If an image filename contains utf-8 characters, then the path stored in to table ewwwio_images is garbled. This happens because utf8_encode() is applied to an already utf-8 string. As a result, the bulk optimizer searches for the garbled filename, and the corresponding image cannot be found/optimized.

For example, the filename:
/var/www/html/wp/wp-content/uploads/2016/12/τεστtestτεστ.jpg
is stored as:
/var/www/html/wp/wp-content/uploads/2016/12/ÏÎµÏÏtestÏÎµÏÏ.jpg