### PR TITLE
Add $fullsize to both ewww action hooks

### DIFF
--- a/unique.php
+++ b/unique.php
@@ -1768,7 +1768,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 	// Toggle the convert process to ON.
 	$convert = true;
 	// Allow other plugins to mangle the image however they like prior to optimization.
-	do_action( 'ewww_image_optimizer_pre_optimization', $file, $type );
+	do_action( 'ewww_image_optimizer_pre_optimization', $file, $type, $fullsize );
 	// Run the appropriate optimization/conversion for the mime-type.
 	switch ( $type ) {
 		case 'image/jpeg':
@@ -2511,7 +2511,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 	} // End switch().
 	// Allow other plugins to run operations on the images after optimization.
 	// NOTE: it is recommended to do any image modifications prior to optimization, otherwise you risk un-optimizing your images here.
-	do_action( 'ewww_image_optimizer_post_optimization', $file, $type );
+	do_action( 'ewww_image_optimizer_post_optimization', $file, $type, $fullsize );
 	// If their cloud api license limit has been exceeded.
 	if ( 'exceeded' == $result ) {
 		if ( strpos( $file, 's3' ) !== 0 && strpos( $file, 's3-uploads' ) === false && $s3_uploads_image && is_file( $file ) ) {


### PR DESCRIPTION
First: Thanks for creating this great plugin! :)

This is most likely a breaking change, as per [your post](https://ewww.io/2016/03/30/ewww-image-optimizer-actions-hooks/) everyone using this hook is probably using it with 2 accepted parameters:

```php
add_action( 'ewww_image_optimizer_pre_optimization', 'special_image_effects', 10, 2 );
```

Seems like this would have to become:

```php
add_action( 'ewww_image_optimizer_pre_optimization', 'special_image_effects', 10, 3 );
```

For this reason, I'd understand if this pull request is rejected.
If it is rejected, I'd like to request some way of having this anyway.

---

Context for what I'm trying to do in general:

Having determined your great plugin as the best choice, I'm trying to optimize each image while removing the metadata for every image except the original uploaded image. Though keeping the ICC color profile for every image including generated ones, because otherwise images with a color space different to sRGB will get displayed with the wrong colors.

To view the effect via <http://regex.info/blog/photo-tech/color-spaces-page2> but bridging to WordPress: 

<http://regex.info/i/cs/Thermos-AdobeRGB-no.jpg> would be the generated image without color profile, e.g. the wordpress size "large" while the original with color profile looks like <http://regex.info/i/cs/Thermos-AdobeRGB-yes.jpg>.

Having modified my dev environment with the changes in this pull request, this is what I'm currently doing:

```php
// https://ewww.io/2016/03/30/ewww-image-optimizer-actions-hooks/
add_action( 'ewww_image_optimizer_post_optimization', 'swp_remove_metadata', 10, 3 );

function swp_remove_metadata( $file, $type, $fullsize = false ) {
    if (!$fullsize && $type === 'image/jpeg') {
        $image = new Imagick($file);

        // set 4:2:0 per https://stackoverflow.com/a/27147203
        $image->setSamplingFactors(array('2x2', '1x1', '1x1'));

        // strip every profile like EXIF etc. except ICC for color profile
        foreach ( $image->getImageProfiles( '*', true ) as $key => $value ) {
            if ( $key !== 'icc' ) {
                $image->removeImageProfile( $key );
            }
        }

        $image->setImageCompressionQuality(85); // WARNING hardcoded

        $image->setInterlaceScheme(Imagick::INTERLACE_PLANE); // progressive

        $image->writeImage();
    }
}
```

Per 

```php
// Allow other plugins to run operations on the images after optimization.
// NOTE: it is recommended to do any image modifications prior to optimization, otherwise you risk un-optimizing your images here.
do_action( 'ewww_image_optimizer_post_optimization', $file, $type );
```

it would probably be better to use ```…_pre_optimization``` instead of ```…_post_optimization```.

Anyway this would be the even bigger request, to have your plugin keep the ICC color profile, but since at least GD can't handle color profiles (https://github.com/libgd/libgd/issues/136), I don't dare to request this 0:-)