### PR TITLE
Add bail-out check for $_GET variable ct_builder

### DIFF
--- a/classes/class-ewwwio-lazy-load.php
+++ b/classes/class-ewwwio-lazy-load.php
@@ -112,7 +112,7 @@ class EWWWIO_Lazy_Load extends EWWWIO_Page_Parser {
 			wp_script_is( 'twentytwenty-twentytwenty', 'enqueued' ) ||
 			preg_match( '/^<\?xml/', $buffer )
 		) {
-			if (! empty( $_GET['ct_builder'] )) {
+			if ( ! empty( $_GET['ct_builder'] ) ) {
 				ewwwio_debug_message( 'oxygen builder' );
 			}
 			if ( empty( $buffer ) ) {

--- a/classes/class-ewwwio-lazy-load.php
+++ b/classes/class-ewwwio-lazy-load.php
@@ -97,6 +97,7 @@ class EWWWIO_Lazy_Load extends EWWWIO_Page_Parser {
 		// Don't lazy load in these cases...
 		$uri = $_SERVER['REQUEST_URI'];
 		if (
+			! empty( $_GET['ct_builder'] ) ||
 			empty( $buffer ) ||
 			is_admin() ||
 			! empty( $_GET['cornerstone'] ) ||
@@ -111,6 +112,9 @@ class EWWWIO_Lazy_Load extends EWWWIO_Page_Parser {
 			wp_script_is( 'twentytwenty-twentytwenty', 'enqueued' ) ||
 			preg_match( '/^<\?xml/', $buffer )
 		) {
+			if (! empty( $_GET['ct_builder'] )) {
+				ewwwio_debug_message( 'oxygen builder' );
+			}
 			if ( empty( $buffer ) ) {
 				ewwwio_debug_message( 'empty buffer' );
 			}


### PR DESCRIPTION
Oxygen Builder sets the $_GET variable in order to indicate we're using the builder. If this is set (we are editing in the builder), we should bail on the lazy-load process.