### PR TITLE
SVG optimization support using svgcleaner - #191

### DIFF
--- a/aux-optimize.php
+++ b/aux-optimize.php
@@ -1087,6 +1087,9 @@ function ewww_image_optimizer_image_scan( $dir, $started = 0 ) {
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) ) {
 		$enabled_types[] = 'application/pdf';
 	}
+	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) ) {
+		$enabled_types[] = 'image/svg+xml';
+	}
 	foreach ( $iterator as $file ) {
 		if ( get_transient( 'ewww_image_optimizer_aux_iterator' ) && get_transient( 'ewww_image_optimizer_aux_iterator' ) > $file_counter ) {
 			continue;
@@ -1404,13 +1407,13 @@ function ewww_image_optimizer_aux_images_script( $hook = '' ) {
 								}
 								$mimetype = ewww_image_optimizer_mimetype( $path, 'i' );
 								// This is a brand new image.
-								if ( preg_match( '/^image\/(jpeg|png|gif)/', $mimetype ) && empty( $already_optimized ) ) {
+								if ( preg_match( '/^image\/(jpeg|png|gif|svg\+xml)/', $mimetype ) && empty( $already_optimized ) ) {
 									$slide_paths[] = array(
 										'path'      => ewww_image_optimizer_relativize_path( $path ),
 										'orig_size' => $image_size,
 									);
 									// This is a changed image.
-								} elseif ( preg_match( '/^image\/(jpeg|png|gif)/', $mimetype ) && ! empty( $already_optimized ) && (int) $already_optimized['image_size'] !== $image_size ) {
+								} elseif ( preg_match( '/^image\/(jpeg|png|gif|svg\+xml)/', $mimetype ) && ! empty( $already_optimized ) && (int) $already_optimized['image_size'] !== $image_size ) {
 									$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->ewwwio_images SET pending = 1 WHERE id = %d", $already_optimized['id'] ) );
 								}
 							}

--- a/bulk.php
+++ b/bulk.php
@@ -1012,6 +1012,9 @@ function ewww_image_optimizer_media_scan( $hook = '' ) {
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) ) {
 		$enabled_types[] = 'application/pdf';
 	}
+	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) ) {
+		$enabled_types[] = 'image/svg+xml';
+	}
 
 	ewww_image_optimizer_debug_log();
 	$starting_memory_usage = memory_get_usage( true );

--- a/common.php
+++ b/common.php
@@ -765,6 +765,8 @@ function ewww_image_optimizer_admin_init() {
 			update_site_option( 'ewww_image_optimizer_gif_level', $ewww_image_optimizer_gif_level );
 			$ewww_image_optimizer_pdf_level = empty( $_POST['ewww_image_optimizer_pdf_level'] ) ? '' : (int) $_POST['ewww_image_optimizer_pdf_level'];
 			update_site_option( 'ewww_image_optimizer_pdf_level', $ewww_image_optimizer_pdf_level );
+			$ewww_image_optimizer_svg_level = empty( $_POST['ewww_image_optimizer_svg_level'] ) ? '' : (int) $_POST['ewww_image_optimizer_svg_level'];
+			update_site_option( 'ewww_image_optimizer_svg_level', $ewww_image_optimizer_svg_level );
 			$ewww_image_optimizer_delete_originals = ( empty( $_POST['ewww_image_optimizer_delete_originals'] ) ? false : true );
 			update_site_option( 'ewww_image_optimizer_delete_originals', $ewww_image_optimizer_delete_originals );
 			$ewww_image_optimizer_jpg_to_png = ( empty( $_POST['ewww_image_optimizer_jpg_to_png'] ) ? false : true );
@@ -858,16 +860,19 @@ function ewww_image_optimizer_admin_init() {
 		! ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) &&
 		! ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) &&
 		! ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ) &&
-		! ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' )
+		! ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) &&
+		! ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' )
 	) {
 		ewww_image_optimizer_set_defaults();
 		update_option( 'ewww_image_optimizer_disable_pngout', true );
+		update_option( 'ewww_image_optimizer_disable_svgcleaner', true );
 		update_option( 'ewww_image_optimizer_optipng_level', 2 );
 		update_option( 'ewww_image_optimizer_pngout_level', 2 );
 		update_option( 'ewww_image_optimizer_metadata_remove', true );
 		update_option( 'ewww_image_optimizer_jpg_level', '10' );
 		update_option( 'ewww_image_optimizer_png_level', '10' );
 		update_option( 'ewww_image_optimizer_gif_level', '10' );
+		update_option( 'ewww_image_optimizer_svg_level', 0 );
 	}
 	// Register all the common EWWW IO settings.
 	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_cloud_key', 'ewww_image_optimizer_cloud_key_sanitize' );
@@ -877,6 +882,7 @@ function ewww_image_optimizer_admin_init() {
 	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_png_level', 'intval' );
 	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_gif_level', 'intval' );
 	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_pdf_level', 'intval' );
+	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_svg_level', 'intval' );
 	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_backup_files', 'boolval' );
 	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_enable_cloudinary', 'boolval' );
 	register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_jpg_quality', 'ewww_image_optimizer_jpg_quality' );
@@ -972,6 +978,10 @@ function ewww_image_optimizer_admin_init() {
 	if ( ! empty( $_GET['ewww_pngout'] ) ) {
 		add_action( 'admin_notices', 'ewww_image_optimizer_pngout_installed' );
 		add_action( 'network_admin_notices', 'ewww_image_optimizer_pngout_installed' );
+	}
+	if ( ! empty( $_GET['ewww_svgcleaner'] ) ) {
+		add_action( 'admin_notices', 'ewww_image_optimizer_svgcleaner_installed' );
+		add_action( 'network_admin_notices', 'ewww_image_optimizer_svgcleaner_installed' );
 	}
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		ewww_image_optimizer_privacy_policy_content();
@@ -1170,6 +1180,7 @@ function ewww_image_optimizer_single_size_optimize( $id, $size ) {
 		'image/png',
 		'image/gif',
 		'application/pdf',
+		'image/svg+xml',
 	);
 	if ( ! in_array( $type, $supported_types, true ) ) {
 		ewwwio_debug_message( "mimetype not supported: $id" );
@@ -1291,6 +1302,9 @@ function ewww_image_optimizer_disable_tools() {
 	}
 	if ( ! defined( 'EWWW_IMAGE_OPTIMIZER_CWEBP' ) ) {
 		define( 'EWWW_IMAGE_OPTIMIZER_CWEBP', false );
+	}
+	if ( ! defined( 'EWWW_IMAGE_OPTIMIZER_SVGCLEANER' ) ) {
+		define( 'EWWW_IMAGE_OPTIMIZER_SVGCLEANER', false );
 	}
 	ewwwio_memory( __FUNCTION__ );
 }
@@ -1745,6 +1759,27 @@ function ewww_image_optimizer_pngout_installed() {
 			'<p>' . sprintf(
 				/* translators: 1: An error message 2: The folder where pngout should be installed */
 				esc_html__( 'Pngout was not installed: %1$s. Make sure this folder is writable: %2$s', 'ewww-image-optimizer' ),
+				( ! empty( $_REQUEST['ewww_error'] ) ? esc_html( sanitize_text_field( wp_unslash( $_REQUEST['ewww_error'] ) ) ) : esc_html( 'unknown error', 'ewww-image-optimizer' ) ), // phpcs:ignore WordPress.Security.NonceVerification
+				esc_html( EWWW_IMAGE_OPTIMIZER_TOOL_PATH )
+			) . "</p>\n" .
+			"</div>\n";
+	}
+}
+
+/**
+ * Display a success or failure message after SVGCLEANER installation.
+ */
+function ewww_image_optimizer_svgcleaner_installed() {
+	if ( ! empty( $_REQUEST['ewww_svgcleaner'] ) && 'success' === $_REQUEST['ewww_svgcleaner'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+		echo "<div id='ewww-image-optimizer-pngout-success' class='notice notice-success fade'>\n" .
+			'<p>' . esc_html__( 'Svgcleaner was successfully installed.', 'ewww-image-optimizer' ) . "</p>\n" .
+			"</div>\n";
+	}
+	if ( ! empty( $_REQUEST['ewww_svgcleaner'] ) && 'failed' === $_REQUEST['ewww_svgcleaner'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+		echo "<div id='ewww-image-optimizer-pngout-failure' class='notice notice-error'>\n" .
+			'<p>' . sprintf(
+				/* translators: 1: An error message 2: The folder where svgcleaner should be installed */
+				esc_html__( 'Svgcleaner was not installed: %1$s. Make sure this folder is writable: %2$s', 'ewww-image-optimizer' ),
 				( ! empty( $_REQUEST['ewww_error'] ) ? esc_html( sanitize_text_field( wp_unslash( $_REQUEST['ewww_error'] ) ) ) : esc_html( 'unknown error', 'ewww-image-optimizer' ) ), // phpcs:ignore WordPress.Security.NonceVerification
 				esc_html( EWWW_IMAGE_OPTIMIZER_TOOL_PATH )
 			) . "</p>\n" .
@@ -2337,7 +2372,7 @@ function ewww_image_optimizer_handle_upload( $params ) {
 		} else {
 			$mime_type = $params['type'];
 		}
-		if ( ( ! is_wp_error( $params ) ) && ewwwio_is_file( $file_path ) && in_array( $mime_type, array( 'image/png', 'image/gif', 'image/jpeg' ), true ) ) {
+		if ( ( ! is_wp_error( $params ) ) && ewwwio_is_file( $file_path ) && in_array( $mime_type, array( 'image/png', 'image/gif', 'image/jpeg', 'image/svg+xml' ), true ) ) {
 			ewww_image_optimizer_resize_upload( $file_path );
 		}
 	}
@@ -3563,7 +3598,7 @@ function ewww_image_optimizer_cloud_restore_single_image( $image ) {
 		ewwwio_memory( __FUNCTION__ );
 		return false;
 	} elseif ( ! empty( $result['body'] ) && strpos( $result['body'], 'missing' ) === false ) {
-		$enabled_types = array( 'image/jpeg', 'image/png', 'image/gif', 'application/pdf' );
+		$enabled_types = array( 'image/jpeg', 'image/png', 'image/gif', 'application/pdf' );	// TODO: add image/svg+xml once svg is supported
 		if ( ! is_dir( dirname( $image['path'] ) ) ) {
 			wp_mkdir_p( dirname( $image['path'] ) );
 		}
@@ -3945,7 +3980,7 @@ function ewww_image_optimizer_cloud_key_sanitize( $key ) {
  * @return bool True if all 'cloud' options are enabled.
  */
 function ewww_image_optimizer_full_cloud() {
-	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) > 10 && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) > 10 ) {
+	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) && ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) > 10 && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) > 10 && ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) > 10 ) {
 		return true;
 	} elseif ( ! defined( 'EWWW_IMAGE_OPTIMIZER_TOOL_PATH' ) ) {
 		return true;
@@ -3962,6 +3997,7 @@ function ewww_image_optimizer_cloud_enable() {
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_png_level', 20 );
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_gif_level', 10 );
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_pdf_level', 10 );
+	//ewww_image_optimizer_set_option( 'ewww_image_optimizer_svg_level', 20 );	// TODO: enable when cloud supports svg
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_backup_files', 1 );
 }
 
@@ -4008,6 +4044,10 @@ function ewww_image_optimizer_cloud_verify( $cache = true, $api_key = '' ) {
 		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) > 0 ) {
 			update_site_option( 'ewww_image_optimizer_pdf_level', 0 );
 			update_option( 'ewww_image_optimizer_pdf_level', 0 );
+		}
+		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) > 10 ) {
+			update_site_option( 'ewww_image_optimizer_svg_level', 10 );
+			update_option( 'ewww_image_optimizer_svg_level', 10 );
 		}
 		update_site_option( 'ewww_image_optimizer_backup_files', '' );
 		update_option( 'ewww_image_optimizer_backup_files', '' );
@@ -4072,7 +4112,8 @@ function ewww_image_optimizer_cloud_verify( $cache = true, $api_key = '' ) {
 		return false;
 	} else {
 		set_transient( 'ewww_image_optimizer_cloud_status', $verified, HOUR_IN_SECONDS );
-		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) < 20 && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) < 20 && ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ) < 20 && ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) ) {
+		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) < 20 && ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) < 20 && ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ) < 20 && ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' )
+				&& ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) < 20 ) {
 			ewww_image_optimizer_cloud_enable();
 		}
 		ewwwio_debug_message( "verification body contents: {$result['body']}" );
@@ -6610,6 +6651,9 @@ function ewww_image_optimizer_attachment_check_variant_level( $id, $type, $meta 
 	if ( 'application/pdf' === $type && 10 !== (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) ) {
 		return $meta;
 	}
+	if ( 'image/svg+xml' === $type && ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) > 20 ) {
+		return $meta;
+	}
 	$compression_level = ewww_image_optimizer_get_level( $type );
 	// Retrieve any records for this image.
 	global $wpdb;
@@ -6922,6 +6966,7 @@ function ewww_image_optimizer_resize_from_meta_data( $meta, $id = null, $log = t
 		'image/png',
 		'image/gif',
 		'application/pdf',
+		'image/svg+xml',
 	);
 	if ( ! in_array( $type, $supported_types, true ) ) {
 		ewwwio_debug_message( "mimetype not supported: $id" );
@@ -7385,6 +7430,7 @@ function ewww_image_optimizer_lr_sync_update( $meta, $id = null ) {
 		'image/png',
 		'image/gif',
 		'application/pdf',
+		'image/svg+xml'
 	);
 	if ( ! in_array( $type, $supported_types, true ) ) {
 		ewwwio_debug_message( "mimetype not supported: $id" );
@@ -7596,14 +7642,17 @@ function ewww_image_optimizer_update_attachment( $meta, $id ) {
 			} // End if().
 		} // End foreach().
 	} // End if().
-	if ( preg_match( '/.jpg$/i', basename( $meta['file'] ) ) ) {
+	if ( preg_match( '/\.jpg$/i', basename( $meta['file'] ) ) ) {
 		$mime = 'image/jpeg';
 	}
-	if ( preg_match( '/.png$/i', basename( $meta['file'] ) ) ) {
+	if ( preg_match( '/\.png$/i', basename( $meta['file'] ) ) ) {
 		$mime = 'image/png';
 	}
-	if ( preg_match( '/.gif$/i', basename( $meta['file'] ) ) ) {
+	if ( preg_match( '/\.gif$/i', basename( $meta['file'] ) ) ) {
 		$mime = 'image/gif';
+	}
+	if ( preg_match( '/\.svg$/i', basename( $meta['file'] ) ) ) {
+		$mime = 'image/svg+xml';
 	}
 	// Update the attachment post with the new mimetype and id.
 	wp_update_post(
@@ -7859,6 +7908,8 @@ function ewww_image_optimizer_quick_mimetype( $path ) {
 			return 'image/webp';
 		case 'pdf':
 			return 'application/pdf';
+		case 'svg':
+			return 'image/svg+xml';
 		default:
 			if ( empty( $pathextension ) && ! ewww_image_optimizer_stream_wrapped( $path ) && ewwwio_is_file( $path ) ) {
 				return ewww_image_optimizer_mimetype( $path, 'i' );
@@ -8088,6 +8139,7 @@ function ewww_image_optimizer_custom_column( $column_name, $id, $meta = null ) {
 		}
 		$skip = ewww_image_optimizer_skip_tools();
 		// Run the appropriate code based on the mimetype.
+		error_log("$file_path>>>$type");
 		switch ( $type ) {
 			case 'image/jpeg':
 				// If jpegtran is missing and should not be skipped.
@@ -8157,6 +8209,22 @@ function ewww_image_optimizer_custom_column( $column_name, $id, $meta = null ) {
 					$convert_desc = '';
 				}
 				break;
+			case 'image/svg+xml':
+				if ( ! $skip['svgcleaner'] && ! EWWW_IMAGE_OPTIMIZER_SVGCLEANER ) {
+					$msg = '<div>' . sprintf(
+						/* translators: %s: name of a tool like jpegtran */
+						__( '%s is missing', 'ewww-image-optimizer' ),
+						'<em>svgcleaner</em>'
+					) . '</div>';
+				} elseif ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) ) {
+					$msg = '<div>' . sprintf(
+						/* translators: %s: JPG, PNG, GIF, PDF or SVG */
+						__( '%s compression disabled', 'ewww-image-optimizer' ),
+						'SVG'
+					) . '</div>';
+				}
+				break;
+			case 'image/gif':
 			default:
 				// Not a supported mimetype.
 				$msg = '<div>' . esc_html__( 'Unsupported file type', 'ewww-image-optimizer' ) . '</div>';
@@ -8948,6 +9016,9 @@ function ewww_image_optimizer_get_level( $type ) {
 	if ( 'application/pdf' === $type ) {
 		return (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' );
 	}
+	if ( 'image/svg+xml' === $type ) {
+		return (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' );
+	}
 	return 0;
 }
 
@@ -9566,6 +9637,7 @@ function ewwwio_debug_info() {
 	ewwwio_debug_message( 'png level: ' . ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ) );
 	ewwwio_debug_message( 'gif level: ' . ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ) );
 	ewwwio_debug_message( 'pdf level: ' . ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) );
+	ewwwio_debug_message( 'svg level: ' . ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) );
 	ewwwio_debug_message( 'bulk delay: ' . ewww_image_optimizer_get_option( 'ewww_image_optimizer_delay' ) );
 	ewwwio_debug_message( 'backup mode: ' . ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_backup_files' ) ? 'on' : 'off' ) );
 	ewwwio_debug_message( 'cloudinary upload: ' . ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_enable_cloudinary' ) ? 'on' : 'off' ) );
@@ -9586,6 +9658,7 @@ function ewwwio_debug_info() {
 		ewwwio_debug_message( 'optipng level: ' . ewww_image_optimizer_get_option( 'ewww_image_optimizer_optipng_level' ) );
 		ewwwio_debug_message( 'pngout disabled: ' . ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_pngout' ) ? 'yes' : 'no' ) );
 		ewwwio_debug_message( 'pngout level: ' . ewww_image_optimizer_get_option( 'ewww_image_optimizer_pngout_level' ) );
+		ewwwio_debug_message( 'svgcleaner disabled: ' . ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_svgcleaner' ) ? 'yes' : 'no' ) );
 	}
 	ewwwio_debug_message( 'effective quality: ' . ewww_image_optimizer_set_jpg_quality( 82 ) );
 	ewwwio_debug_message( 'parallel optimization: ' . ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_parallel_optimization' ) ? 'on' : 'off' ) );
@@ -9905,6 +9978,7 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 		$skip['pngout']   = true;
 		$skip['pngquant'] = true;
 		$skip['webp']     = true;
+		$skip['svgcleaner'] = true;
 	}
 	if ( ! $skip['jpegtran'] && ! EWWW_IMAGE_OPTIMIZER_NOEXEC ) {
 		if ( EWWW_IMAGE_OPTIMIZER_JPEGTRAN ) {
@@ -9982,6 +10056,18 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 			$speed_score += 10;
 		} else {
 			$speed_recommendations[] = __( 'Install WebP.', 'ewww-image-optimizer' ) . ewwwio_get_help_link( 'https://docs.ewww.io/article/6-the-plugin-says-i-m-missing-something', '585371e3c697912ffd6c0ba1' );
+		}
+	}
+	if ( ! $skip['svgcleaner'] && ! EWWW_IMAGE_OPTIMIZER_NOEXEC ) {
+		if ( EWWW_IMAGE_OPTIMIZER_SVGCLEANER ) {
+			$svgcleaner_version = ewww_image_optimizer_tool_found( EWWW_IMAGE_OPTIMIZER_SVGCLEANER, 'p' );
+		}
+		if ( ! empty( $svgcleaner_version ) ) {
+			$speed_score += 0;	//TODO: not sure here so 0 increase
+		} else {
+			$speed_recommendations[] = __( 'Install svgcleaner', 'ewww-image-optimizer' ) . ': <a href="' . admin_url( 'admin.php?action=ewww_image_optimizer_install_svgcleaner' ) . '">'
+				//. esc_html__( 'automatically', 'ewww-image-optimizer' ) . '</a> | <a href="https://docs.ewww.io/article/13-installing-pngout" data-beacon-article="5854531bc697912ffd6c1afa">' . esc_html__( 'manually', 'ewww-image-optimizer' ) . '</a>' //TODO: reference article
+				;
 		}
 	}
 	if ( get_option( 'easyio_lazy_load' ) || ewww_image_optimizer_get_option( 'ewww_image_optimizer_lazy_load' ) ) {
@@ -10282,6 +10368,7 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 			<input type='hidden' id='ewww_image_optimizer_png_level' name='ewww_image_optimizer_png_level' value='<?php echo (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_png_level' ); ?>'>
 			<input type='hidden' id='ewww_image_optimizer_gif_level' name='ewww_image_optimizer_gif_level' value='<?php echo (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_gif_level' ); ?>'>
 			<input type='hidden' id='ewww_image_optimizer_pdf_level' name='ewww_image_optimizer_pdf_level' value='<?php echo (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ); ?>'>
+			<input type='hidden' id='ewww_image_optimizer_svg_level' name='ewww_image_optimizer_svg_level' value='<?php echo (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ); ?>'>
 	<?php elseif ( 'singlesite' === $network && ewww_image_optimizer_get_option( 'ewww_image_optimizer_exactdn' ) ) : ?>
 			<p><strong><?php esc_html_e( 'Easy IO is optimizing your site, no more configuration needed!', 'ewww-image-optimizer' ); ?></strong><br>
 		<?php if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) : ?>
@@ -10455,6 +10542,25 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 							</option>
 							<option <?php disabled( $disable_level ); ?> value='20' <?php selected( ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ), 20 ); ?>>
 								<?php esc_html_e( 'High Compression', 'ewww-image-optimizer' ); ?> *
+							</option>
+						</select>
+					</td>
+				</tr>
+				<tr>
+					<th scope='row'>
+						<label for='ewww_image_optimizer_svg_level'><?php esc_html_e( 'SVG Optimization Level', 'ewww-image-optimizer' ); ?></label>
+						<?php ewwwio_help_link( 'https://docs.ewww.io/article/7-basic-configuration', '585373d5c697912ffd6c0bb2' ); ?>
+					</th>
+					<td>
+						<select id='ewww_image_optimizer_svg_level' name='ewww_image_optimizer_svg_level'>
+							<option value='0' <?php selected( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ), 0 ); ?>>
+								<?php esc_html_e( 'No Compression', 'ewww-image-optimizer' ); ?>
+							</option>
+							<option <?php disabled( $free_exec ); ?> value='1' <?php selected( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ), 1 ); ?>>
+								<?php esc_html_e( 'Minimal', 'ewww-image-optimizer' ); ?>
+							</option>
+							<option <?php disabled( $free_exec ); ?> value='10' <?php selected( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ), 10 ); ?>>
+								<?php esc_html_e( 'Default', 'ewww-image-optimizer' ); ?>
 							</option>
 						</select>
 					</td>
@@ -11484,6 +11590,9 @@ function ewww_image_optimizer_remove_cloud_key( $redirect = true ) {
 	}
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) > 0 ) {
 		ewww_image_optimizer_set_option( 'ewww_image_optimizer_pdf_level', 0 );
+	}
+	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) > 0 ) {
+		ewww_image_optimizer_set_option( 'ewww_image_optimizer_svg_level', $default_level );
 	}
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_cloud_exceeded', 0 );
 	delete_transient( 'ewww_image_optimizer_cloud_status' );

--- a/common.php
+++ b/common.php
@@ -10053,7 +10053,7 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 		if ( EWWW_IMAGE_OPTIMIZER_SVGCLEANER ) {
 			$svgcleaner_version = ewww_image_optimizer_tool_found( EWWW_IMAGE_OPTIMIZER_SVGCLEANER, 's' );
 		}
-		if ( ! empty( $svgcleaner_version ) ) {
+		if ( empty( $svgcleaner_version ) ) {
 			$speed_recommendations[] = '<a href="' . admin_url( 'admin.php?action=ewww_image_optimizer_install_svgcleaner' ) . '">' . __( 'Install svgcleaner', 'ewww-image-optimizer' ) . '</a>';
 		}
 	}

--- a/common.php
+++ b/common.php
@@ -11582,7 +11582,7 @@ function ewww_image_optimizer_remove_cloud_key( $redirect = true ) {
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_pdf_level' ) > 0 ) {
 		ewww_image_optimizer_set_option( 'ewww_image_optimizer_pdf_level', 0 );
 	}
-	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_svg_level' ) > 0 ) {
+	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_svgcleaner' ) ) {
 		ewww_image_optimizer_set_option( 'ewww_image_optimizer_svg_level', 0 );
 	}
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_cloud_exceeded', 0 );

--- a/common.php
+++ b/common.php
@@ -3598,7 +3598,7 @@ function ewww_image_optimizer_cloud_restore_single_image( $image ) {
 		ewwwio_memory( __FUNCTION__ );
 		return false;
 	} elseif ( ! empty( $result['body'] ) && strpos( $result['body'], 'missing' ) === false ) {
-		$enabled_types = array( 'image/jpeg', 'image/png', 'image/gif', 'application/pdf' );	// TODO: add image/svg+xml once svg is supported
+		$enabled_types = array( 'image/jpeg', 'image/png', 'image/gif', 'application/pdf' ); // TODO: add image/svg+xml once svg is supported.
 		if ( ! is_dir( dirname( $image['path'] ) ) ) {
 			wp_mkdir_p( dirname( $image['path'] ) );
 		}
@@ -3997,7 +3997,7 @@ function ewww_image_optimizer_cloud_enable() {
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_png_level', 20 );
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_gif_level', 10 );
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_pdf_level', 10 );
-	//ewww_image_optimizer_set_option( 'ewww_image_optimizer_svg_level', 20 );	// TODO: enable when cloud supports svg
+	// ewww_image_optimizer_set_option( 'ewww_image_optimizer_svg_level', 20 ); //TODO: enable when cloud supports svg.
 	ewww_image_optimizer_set_option( 'ewww_image_optimizer_backup_files', 1 );
 }
 
@@ -7430,7 +7430,7 @@ function ewww_image_optimizer_lr_sync_update( $meta, $id = null ) {
 		'image/png',
 		'image/gif',
 		'application/pdf',
-		'image/svg+xml'
+		'image/svg+xml',
 	);
 	if ( ! in_array( $type, $supported_types, true ) ) {
 		ewwwio_debug_message( "mimetype not supported: $id" );
@@ -8139,7 +8139,6 @@ function ewww_image_optimizer_custom_column( $column_name, $id, $meta = null ) {
 		}
 		$skip = ewww_image_optimizer_skip_tools();
 		// Run the appropriate code based on the mimetype.
-		error_log("$file_path>>>$type");
 		switch ( $type ) {
 			case 'image/jpeg':
 				// If jpegtran is missing and should not be skipped.
@@ -9972,12 +9971,12 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 	}
 	$skip = ewww_image_optimizer_skip_tools();
 	if ( ewww_image_optimizer_easy_active() ) {
-		$skip['jpegtran'] = true;
-		$skip['optipng']  = true;
-		$skip['gifsicle'] = true;
-		$skip['pngout']   = true;
-		$skip['pngquant'] = true;
-		$skip['webp']     = true;
+		$skip['jpegtran']   = true;
+		$skip['optipng']    = true;
+		$skip['gifsicle']   = true;
+		$skip['pngout']     = true;
+		$skip['pngquant']   = true;
+		$skip['webp']       = true;
 		$skip['svgcleaner'] = true;
 	}
 	if ( ! $skip['jpegtran'] && ! EWWW_IMAGE_OPTIMIZER_NOEXEC ) {
@@ -10063,11 +10062,10 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 			$svgcleaner_version = ewww_image_optimizer_tool_found( EWWW_IMAGE_OPTIMIZER_SVGCLEANER, 'p' );
 		}
 		if ( ! empty( $svgcleaner_version ) ) {
-			$speed_score += 0;	//TODO: not sure here so 0 increase
+			$speed_score += 0; // TODO: not sure here so 0 increase.
 		} else {
-			$speed_recommendations[] = __( 'Install svgcleaner', 'ewww-image-optimizer' ) . ': <a href="' . admin_url( 'admin.php?action=ewww_image_optimizer_install_svgcleaner' ) . '">'
-				//. esc_html__( 'automatically', 'ewww-image-optimizer' ) . '</a> | <a href="https://docs.ewww.io/article/13-installing-pngout" data-beacon-article="5854531bc697912ffd6c1afa">' . esc_html__( 'manually', 'ewww-image-optimizer' ) . '</a>' //TODO: reference article
-				;
+			$speed_recommendations[] = __( 'Install svgcleaner', 'ewww-image-optimizer' ) . ': <a href="' . admin_url( 'admin.php?action=ewww_image_optimizer_install_svgcleaner' ) . '">';
+				// esc_html__( 'automatically', 'ewww-image-optimizer' ) . '</a> | <a href="https://docs.ewww.io/article/13-installing-pngout" data-beacon-article="5854531bc697912ffd6c1afa">' . esc_html__( 'manually', 'ewww-image-optimizer' ) . '</a>' //TODO: create reference article.
 		}
 	}
 	if ( get_option( 'easyio_lazy_load' ) || ewww_image_optimizer_get_option( 'ewww_image_optimizer_lazy_load' ) ) {

--- a/unique.php
+++ b/unique.php
@@ -2767,9 +2767,7 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 			);
 			// If svgcleaner is disabled.
 			$compression_level = 0;
-			if ( ! empty( $ewww_webp_only ) ) {
-				$optimize = false;
-			} elseif ( ! $skip['svgcleaner'] && ! $tools['SVGCLEANER'] ) {
+			if ( ! $skip['svgcleaner'] && ! $tools['SVGCLEANER'] ) {
 				/* translators: %s: name of a tool like jpegtran */
 				$result = sprintf( __( '%s is missing', 'ewww-image-optimizer' ), '<em>svgcleaner</em>' );
 			} else {

--- a/unique.php
+++ b/unique.php
@@ -489,9 +489,9 @@ function ewww_image_optimizer_skip_tools() {
 	$skip['optipng']  = false;
 	$skip['gifsicle'] = false;
 	// Except these which are off by default.
-	$skip['pngout']   = true;
-	$skip['pngquant'] = true;
-	$skip['webp']     = true;
+	$skip['pngout']     = true;
+	$skip['pngquant']   = true;
+	$skip['webp']       = true;
 	$skip['svgcleaner'] = true;
 	// If the user has disabled a tool, we aren't going to bother checking to see if it is there.
 	if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) || ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_level' ) > 10 || ( defined( 'EWWW_IMAGE_OPTIMIZER_NOEXEC' ) && EWWW_IMAGE_OPTIMIZER_NOEXEC ) ) {
@@ -744,12 +744,11 @@ function ewww_image_optimizer_notice_utils( $quiet = null ) {
 				/* translators: 1: automatically (link) 2: manually (link) */
 				esc_html__( 'You are missing svgleaner. Install %1$s or %2$s.', 'ewww-image-optimizer' ),
 				"<a href='" . esc_url( $svgcleaner_install_url ) . "'>" . esc_html__( 'automatically', 'ewww-image-optimizer' ) . '</a>',
-				// TODO: provide article for installing svgcleaner
+				// TODO: provide article for installing svgcleaner.
 				'<a href="https://docs.ewww.io/article/13-installing-pngout" data-beacon-article="5854531bc697912ffd6c1afa">' . esc_html__( 'manually', 'ewww-image-optimizer' ) . '</a>'
 			) .
 			'</p></div>';
-		}
-		else {
+		} else {
 			echo "<div id='ewww-image-optimizer-warning-opt-missing' class='notice notice-error'><p>" .
 			sprintf(
 				/* translators: 1-6: jpegtran, optipng, pngout, pngquant, gifsicle, and cwebp (links) 7: Settings Page (link) 8: Installation Instructions (link) */
@@ -798,22 +797,22 @@ function ewww_image_optimizer_exec_check() {
  */
 function ewww_image_optimizer_path_check( $j = true, $o = true, $g = true, $p = true, $q = true, $w = true, $s = true ) {
 	ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
-	$jpegtran = false;
-	$optipng  = false;
-	$gifsicle = false;
-	$pngout   = false;
-	$pngquant = false;
-	$webp     = false;
+	$jpegtran   = false;
+	$optipng    = false;
+	$gifsicle   = false;
+	$pngout     = false;
+	$pngquant   = false;
+	$webp       = false;
 	$svgcleaner = false;
 	ewww_image_optimizer_define_noexec();
 	if ( EWWW_IMAGE_OPTIMIZER_NOEXEC ) {
 		return array(
-			'JPEGTRAN' => false,
-			'OPTIPNG'  => false,
-			'GIFSICLE' => false,
-			'PNGOUT'   => false,
-			'PNGQUANT' => false,
-			'CWEBP'    => false,
+			'JPEGTRAN'   => false,
+			'OPTIPNG'    => false,
+			'GIFSICLE'   => false,
+			'PNGOUT'     => false,
+			'PNGQUANT'   => false,
+			'CWEBP'      => false,
 			'SVGCLEANER' => false,
 		);
 	}
@@ -994,12 +993,12 @@ function ewww_image_optimizer_path_check( $j = true, $o = true, $g = true, $p = 
 	}
 	ewwwio_memory( __FUNCTION__ );
 	return array(
-		'JPEGTRAN' => $jpegtran,
-		'OPTIPNG'  => $optipng,
-		'GIFSICLE' => $gifsicle,
-		'PNGOUT'   => $pngout,
-		'PNGQUANT' => $pngquant,
-		'CWEBP'    => $webp,
+		'JPEGTRAN'   => $jpegtran,
+		'OPTIPNG'    => $optipng,
+		'GIFSICLE'   => $gifsicle,
+		'PNGOUT'     => $pngout,
+		'PNGQUANT'   => $pngquant,
+		'CWEBP'      => $webp,
 		'SVGCLEANER' => $svgcleaner,
 	);
 }
@@ -1196,10 +1195,10 @@ function ewww_image_optimizer_md5check( $path ) {
 		'66568f3b31f8f22deef38aa6ba3d2be19516514e94b7d623cd2ce2a290ccdd69', // cwebp-sol   1.0.3, EWWW 5.1.0.
 		'e1041c5486fb4e57e31155c45d66117f8fc270e5a56a1049408a05f54bd52969', // cwebp.exe   1.0.3, EWWW 5.1.0.
 		// end cwebp.
-		'15d8b7d54b73059a9a63ab3d5ca8201cd30c2f6fc59fc068f7bd6c85e6a22420', // svgcleaner-linux 0.9.5
-		'c88c1961374b3edc93a29376ccbd447a514c1cda335fe6a868c0dac6d77c79fa', // svgcleaner-mac 0.9.5
-		'5f0b5d64e7975275cd8649f4b29bd0526ba06961aef92aa9812e26443e454fe0', // svgcleaner.exe 0.9.5
-		// end svgcleaner
+		'15d8b7d54b73059a9a63ab3d5ca8201cd30c2f6fc59fc068f7bd6c85e6a22420', // svgcleaner-linux 0.9.5.
+		'c88c1961374b3edc93a29376ccbd447a514c1cda335fe6a868c0dac6d77c79fa', // svgcleaner-mac 0.9.5.
+		'5f0b5d64e7975275cd8649f4b29bd0526ba06961aef92aa9812e26443e454fe0', // svgcleaner.exe 0.9.5.
+		// end svgcleaner.
 	);
 	foreach ( $valid_sums as $checksum ) {
 		if ( $checksum === $binary_sum ) {
@@ -1536,7 +1535,7 @@ function ewww_image_optimizer_tool_found( $path, $tool ) {
 				return esc_html__( 'unknown', 'ewww-image-optimizer' );
 			}
 			break;
-		case 's': //svgcleaner
+		case 's': // svgcleaner.
 			exec( "$path --version 2>&1", $svgcleaner_version );
 			if ( ewww_image_optimizer_iterable( $svgcleaner_version ) ) {
 				ewwwio_debug_message( "$path: {$svgcleaner_version[0]}" );
@@ -1545,7 +1544,7 @@ function ewww_image_optimizer_tool_found( $path, $tool ) {
 				break;
 			}
 			if ( ! empty( $svgcleaner_version ) && strpos( $svgcleaner_version[0], 'svgcleaner' ) === 0 ) {
-				$svgcleaner_out = explode(" ", $svgcleaner_version[0]);
+				$svgcleaner_out = explode( ' ', $svgcleaner_version[0] );
 				ewwwio_debug_message( 'optimizer found' );
 				return $svgcleaner_out[1];
 			}
@@ -1927,13 +1926,13 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 	}
 	$skip = ewww_image_optimizer_skip_tools();
 	if ( EWWW_IMAGE_OPTIMIZER_CLOUD ) {
-		$skip['jpegtran'] = true;
-		$skip['optipng']  = true;
-		$skip['gifsicle'] = true;
-		$skip['pngout']   = true;
-		$skip['pngquant'] = true;
-		$skip['webp']     = true;
-		$skip['svgcleaner'] = true;	// TODO: not sure here - cloud has no SVG support (yet)
+		$skip['jpegtran']   = true;
+		$skip['optipng']    = true;
+		$skip['gifsicle']   = true;
+		$skip['pngout']     = true;
+		$skip['pngquant']   = true;
+		$skip['webp']       = true;
+		$skip['svgcleaner'] = true; // TODO: not sure here - cloud has no SVG support (yet).
 	}
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_metadata_skip_full' ) && $fullsize ) {
 		$keep_metadata = true;
@@ -2789,8 +2788,9 @@ function ewww_image_optimizer( $file, $gallery_type = 4, $converted = false, $ne
 				$svgcleaner_options = array(
 					'--allow-bigger-file',
 				);
-				if ( $compression_level == 1 ) {
-					array_push($svgcleaner_options,
+				if ( 1 === $compression_level ) {
+					array_push(
+						$svgcleaner_options,
 						'--paths-to-relative=no',
 						'--remove-unused-segments=no',
 						'--convert-segments=no',
@@ -3114,7 +3114,7 @@ function ewww_image_optimizer_install_svgcleaner() {
 	if ( ! extension_loaded( 'zlib' ) || ! class_exists( 'PharData' ) ) {
 		$download_error = __( 'zlib or phar extension missing from PHP', 'ewww-image-optimizer' );
 	}
-	$os_chmod = true;
+	$os_chmod  = true;
 	$os_binary = 'svgcleaner';
 	if ( PHP_OS === 'Linux' ) {
 		$arch_type = 'x86_64';
@@ -3122,12 +3122,10 @@ function ewww_image_optimizer_install_svgcleaner() {
 			$arch_type = php_uname( 'm' );
 		}
 		$os_string = 'linux_' . $arch_type;
-	}
-	elseif ( PHP_OS === 'Darwin' ) {
+	} elseif ( PHP_OS === 'Darwin' ) {
 		$os_string = 'macos';
-	}
-	elseif ( PHP_OS === 'WINNT' ) {
-		$os_chmod = false;
+	} elseif ( PHP_OS === 'WINNT' ) {
+		$os_chmod  = false;
 		$os_string = 'win32';
 		$os_binary = 'svgcleaner.exe';
 	}
@@ -3146,8 +3144,8 @@ function ewww_image_optimizer_install_svgcleaner() {
 				rename( $download_result, $tmpname );
 				$download_result = $tmpname;
 
-				$pkg_gzipped  = new PharData( $download_result );
-				$pkg_tarball  = $pkg_gzipped->decompress();
+				$pkg_gzipped     = new PharData( $download_result );
+				$pkg_tarball     = $pkg_gzipped->decompress();
 				$download_result = $pkg_tarball->getPath();
 				$pkg_tarball->extractTo(
 					EWWW_IMAGE_OPTIMIZER_BINARY_PATH,
@@ -3157,7 +3155,7 @@ function ewww_image_optimizer_install_svgcleaner() {
 				if ( ewwwio_is_file( EWWW_IMAGE_OPTIMIZER_BINARY_PATH . $os_binary ) ) {
 					if ( ! rename( EWWW_IMAGE_OPTIMIZER_BINARY_PATH . $os_binary, $tool_path . $os_binary ) ) {
 						if ( empty( $download_error ) ) {
-							$download_error = __( 'could not move ' . $os_binary, 'ewww-image-optimizer' );
+							$download_error = __( 'could not move svgcleaner', 'ewww-image-optimizer' );
 						}
 					}
 					if ( $os_chmod && ! chmod( $tool_path . $os_binary, 0755 ) ) {
@@ -3186,7 +3184,7 @@ function ewww_image_optimizer_install_svgcleaner() {
 		$sendback = add_query_arg(
 			array(
 				'ewww_svgcleaner' => 'failed',
-				'ewww_error'  => urlencode( $download_error ),
+				'ewww_error'      => urlencode( $download_error ),
 			),
 			remove_query_arg( array( 'ewww_svgcleaner', 'ewww_error' ), wp_get_referer() )
 		);


### PR DESCRIPTION
Hi,
  this is the promised pull request adding SVG support. As we talked it's off by default, and svgcleaner binary is installed from github. Cleanup works, I've implemented 2 levels - 'Minimal' that is less intrusive and 'Default' using svgcleaner default settings.

![Screenshot_2020-09-18 Media Library ‹ Test — WordPress](https://user-images.githubusercontent.com/1709205/93621976-a4ba1000-f9dc-11ea-9079-dfb843c00dd8.png)

For testing, you need to allow SVG uploads either by `define('ALLOW_UNFILTERED_UPLOADS', true);` or by changing site settings.

There few TODOs, marked also in the code:
- most of them are related to cloud optimization of SVG, don't know if you plan it but i've added remarks where I think the changes will be needed
- they also mark missing future references to docs related to SVG cleanup, because well, they don't exists yet ;-)
- speed_score is increased by 0 if svgcleaner is present, not sure if you want increase it when SVG enable
- I've extended the logic that displays install banner, but it can not handle situation when pngout and svgcleaner are both missing. Tell me how to change the logic and I'll improve that.

Thanks you
  Sam
