### PR TITLE
make php 7.2 the minimum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
     - master
 
 php:
-  - 7.1
+  - 7.2
   - 7.4
 
 services:
@@ -22,11 +22,11 @@ services:
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=5.4 WP_MULTISITE=0
+  - WP_VERSION=5.6 WP_MULTISITE=0
 
 jobs:
   include:
-    - php: 7.1
+    - php: 7.2
       env: WP_VERSION=latest WP_MULTISITE=1 WPSNIFF=1
     - php: 7.4
       env: WP_VERSION=latest WP_MULTISITE=1 WPSNIFF=1

--- a/common.php
+++ b/common.php
@@ -1206,9 +1206,9 @@ function ewww_image_optimizer_admin_init() {
 		add_action( 'admin_footer', 'ewww_image_optimizer_lr_sync_script' );
 	}
 	// Increase the version when the next bump is coming.
-	if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50600 ) {
-		add_action( 'network_admin_notices', 'ewww_image_optimizer_php55_warning' );
-		add_action( 'admin_notices', 'ewww_image_optimizer_php55_warning' );
+	if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 70200 ) {
+		add_action( 'network_admin_notices', 'ewww_image_optimizer_php72_warning' );
+		add_action( 'admin_notices', 'ewww_image_optimizer_php72_warning' );
 	}
 	ewwwio_memory( __FUNCTION__ );
 }
@@ -2172,10 +2172,10 @@ function ewww_image_optimizer_notice_exactdn_sp_conflict() {
 }
 
 /**
- * Display a notice that PHP version 5.5 support is going away.
+ * Display a notice that PHP version 7.2 will be required in a future version.
  */
-function ewww_image_optimizer_php55_warning() {
-	echo '<div id="ewww-image-optimizer-notice-php55" class="notice notice-info"><p><a href="https://docs.ewww.io/article/55-upgrading-php" target="_blank" data-beacon-article="5ab2baa6042863478ea7c2ae">' . esc_html__( 'The next major release of EWWW Image Optimizer will require PHP 5.6 or greater. Newer versions of PHP, like 7.1 and 7.2, are significantly faster and much more secure. If you are unsure how to upgrade to a supported version, ask your webhost for instructions.', 'ewww-image-optimizer' ) . '</a></p></div>';
+function ewww_image_optimizer_php72_warning() {
+	echo '<div id="ewww-image-optimizer-notice-php72" class="notice notice-info"><p><a href="https://docs.ewww.io/article/55-upgrading-php" target="_blank" data-beacon-article="5ab2baa6042863478ea7c2ae">' . esc_html__( 'The next release of EWWW Image Optimizer will require PHP 7.2 or greater. Newer versions of PHP are significantly faster and much more secure. If you are unsure how to upgrade to a supported version, ask your webhost for instructions.', 'ewww-image-optimizer' ) . '</a></p></div>';
 }
 
 /**

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -14,8 +14,8 @@ Plugin URI: https://wordpress.org/plugins/ewww-image-optimizer/
 Description: Reduce file sizes for images within WordPress including NextGEN Gallery and GRAND FlAGallery. Uses jpegtran, optipng/pngout, and gifsicle.
 Author: Exactly WWW
 Version: 6.3.0.5
-Requires at least: 5.5
-Requires PHP: 7.1
+Requires at least: 5.6
+Requires PHP: 7.2
 Author URI: https://ewww.io/
 License: GPLv3
 */
@@ -38,7 +38,7 @@ if ( ! defined( 'EWWW_IMAGE_OPTIMIZER_TOOL_PATH' ) ) {
 }
 
 // Check the PHP version.
-if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 50600 ) {
+if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70200 ) {
 	add_action( 'network_admin_notices', 'ewww_image_optimizer_unsupported_php' );
 	add_action( 'admin_notices', 'ewww_image_optimizer_unsupported_php' );
 	// Loads the plugin translations.
@@ -82,11 +82,11 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 50600 ) {
 	define( 'EWWW_IMAGE_OPTIMIZER_IMAGES_PATH', plugin_dir_path( __FILE__ ) . 'images/' );
 
 	/**
-	 * All the 'unique' functions for the core EWWW I.O. plugin.
+	 * All the 'unique' functions for the core EWWW IO plugin.
 	 */
 	require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'unique.php' );
 	/**
-	 * All the 'common' functions for both EWWW I.O. plugins.
+	 * All the 'common' functions for both EWWW IO plugins.
 	 */
 	require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'common.php' );
 	/**
@@ -125,7 +125,7 @@ if ( ! function_exists( 'ewww_image_optimizer_unsupported_php' ) ) {
 	 * Display a notice that the PHP version is too old.
 	 */
 	function ewww_image_optimizer_unsupported_php() {
-		echo '<div id="ewww-image-optimizer-warning-php" class="error"><p><a href="https://docs.ewww.io/article/55-upgrading-php" target="_blank" data-beacon-article="5ab2baa6042863478ea7c2ae">' . esc_html__( 'EWWW Image Optimizer requires PHP 5.6 or greater. Newer versions of PHP, like 7.1 and 7.2, are significantly faster and much more secure. If you are unsure how to upgrade to a supported version, ask your webhost for instructions.', 'ewww-image-optimizer' ) . '</a></p></div>';
+		echo '<div id="ewww-image-optimizer-warning-php" class="error"><p><a href="https://docs.ewww.io/article/55-upgrading-php" target="_blank" data-beacon-article="5ab2baa6042863478ea7c2ae">' . esc_html__( 'EWWW Image Optimizer requires PHP 7.2 or greater. Newer versions of PHP are significantly faster and much more secure. If you are unsure how to upgrade to a supported version, ask your webhost for instructions.', 'ewww-image-optimizer' ) . '</a></p></div>';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: nosilver4u
 Donate link: https://ewww.io/donate/
 Tags: optimize, image, convert, webp, resize, compress, lazy load, optimization, lossless, lossy, seo, scale
-Requires at least: 5.5
-Tested up to: 5.8
-Requires PHP: 7.1
+Requires at least: 5.6
+Tested up to: 5.9
+Requires PHP: 7.2
 Stable tag: 6.3.0
 License: GPLv3
 
@@ -149,6 +149,7 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 * fixed: Easy IO misses some image URLs on multi-site when using domain-mapping
 * fixed: SVG level cannot be set when using API if svgcleaner was not installed previously
 * fixed: Easy IO URL rewriter changing links if they matched a custom upload folder
+* removed: PHP 7.1 is no longer supported
 
 = 6.3.0 =
 * added: EIO_LAZY_FOLD override to configure number of images above-the-fold that will be skipped by Lazy Load


### PR DESCRIPTION
Updated the plugin headers, readme, and admin notices. However, the admin notices should not be seen anymore, since WP is supposed to even prevent activation of a plugin if the PHP version in the plugin header prohibits it.