### PR TITLE
remove parallel mode

### DIFF
--- a/classes/class-ewwwio-tracking.php
+++ b/classes/class-ewwwio-tracking.php
@@ -156,7 +156,6 @@ class EWWWIO_Tracking {
 		$data['disable_pngout']         = (bool) ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_pngout' );
 		$data['pngout_level']           = ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ? 9 : (int) ewww_image_optimizer_get_option( 'ewww_image_optimizer_pngout_level' );
 		$data['jpg_quality']            = (int) apply_filters( 'jpeg_quality', 82 );
-		$data['parallel_opt']           = (bool) ewww_image_optimizer_get_option( 'ewww_image_optimizer_parallel_optimization' );
 		$data['background_opt']         = (bool) ewww_image_optimizer_get_option( 'ewww_image_optimizer_background_optimization' );
 		$data['scheduled_opt']          = (bool) ewww_image_optimizer_get_option( 'ewww_image_optimizer_auto' );
 		$data['include_media_folders']  = (bool) ewww_image_optimizer_get_option( 'ewww_image_optimizer_include_media_paths' );

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -13,7 +13,7 @@ Plugin Name: EWWW Image Optimizer
 Plugin URI: https://wordpress.org/plugins/ewww-image-optimizer/
 Description: Smaller Images, Faster Sites, Happier Visitors. Comprehensive image optimization that doesn't require a degree in rocket science.
 Author: Exactly WWW
-Version: 6.9.2.4
+Version: 6.9.2.5
 Requires at least: 5.8
 Requires PHP: 7.2
 Author URI: https://ewww.io/
@@ -106,7 +106,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70200 ) {
 	 */
 	require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'classes/class-eio-base.php' );
 	/**
-	 * The various class extensions for parallel and background optimization.
+	 * The various class extensions for background optimization.
 	 */
 	require_once( EWWW_IMAGE_OPTIMIZER_PLUGIN_PATH . 'classes/class-ewwwio-media-background-process.php' );
 	/**


### PR DESCRIPTION
First, there is the potential that parallel mode actually slows things down because some versions of cURL have a minimum 1s timeout rather than 0.01s as requested. Running each image in a separate process is prone to other issues which we've had to work around over the years. Plus, it prevents some functionality from being used altogether, like the search for 2x images not created by Jordy's Perfect Images plugin. It was already pulled from the UI due to this potential for problems, now it's just gone!