### PR TITLE
track resize attempts

### DIFF
--- a/classes/class-ewww-image.php
+++ b/classes/class-ewww-image.php
@@ -106,6 +106,36 @@ class EWWW_Image {
 	public $resize = null;
 
 	/**
+	 * The width setting (in pixels) when this image was last attempted to be resized.
+	 *
+	 * This is not the actual width of the image, but used to check if the settings
+	 * have changed since the last attempt.
+	 *
+	 * @var int $resized_width
+	 */
+	public $resized_width = 0;
+
+	/**
+	 * The height setting (in pixels) when this image was last attempted to be resized.
+	 *
+	 * This is not the actual height of the image, but used to check if the settings
+	 * have changed since the last attempt.
+	 *
+	 * @var int $resized_height
+	 */
+	public $resized_height = 0;
+
+	/**
+	 * An error code from when this image was last attempted to be resized.
+	 *
+	 * 0 = No error, 1 = WP_Image_Editor error, 2 = scaled version was too large,
+	 * 3 = some other error, like an unwritable or missing image.
+	 *
+	 * @var int $resize_error
+	 */
+	public $resize_error = 0;
+
+	/**
 	 * The suffix added to the converted file, to be applied also to thumbs.
 	 *
 	 * @var string $suffix

--- a/common.php
+++ b/common.php
@@ -6324,7 +6324,7 @@ function ewww_image_optimizer_update_resize_results( $attachment, $resized_width
 	if ( ! seems_utf8( $updates['path'] ) ) {
 		$updates['path'] = mb_convert_encoding( $updates['path'], 'UTF-8' );
 	}
-	if ( is_object( $ewww_image ) && $ewww_image instanceof EWWW_Image && $attachment === $ewww_image->path ) {
+	if ( is_object( $ewww_image ) && $ewww_image instanceof EWWW_Image && $attachment === $ewww_image->file ) {
 		$ewww_image->resized_width  = (int) $resized_width;
 		$ewww_image->resized_height = (int) $resized_height;
 		$ewww_image->resize_error   = (int) $resize_error;

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -34,7 +34,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70300 ) {
 	add_action( 'admin_notices', 'ewww_image_optimizer_dual_plugin' );
 } elseif ( false === strpos( add_query_arg( '', '' ), 'ewwwio_disable=1' ) ) {
 
-	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 723 );
+	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 723.1 );
 	// Initialize a global.
 	$ewww_defer = true;
 

--- a/readme.txt
+++ b/readme.txt
@@ -143,8 +143,11 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 = 7.2.4 =
 *Release Date - TBD*
 
+* added: Store resize results to prevent repeated attempts to scale images that yield larger filesizes
+* added: warning to remove outdated AGR plugin
 * fixed: JS WebP can't check for local images when using S3 on multisite in sub-folder mode
 * fixed: corrupted images (with an unrecognized file header) being repeatedly scanned by the bulk/scheduled optimizer
+* fixed: GIF images not offloaded by WP Offload Media when operating in free cloud-based mode due to no thumbnail generation
 
 = 7.2.3 =
 *Release Date - January 4, 2024*


### PR DESCRIPTION
Prevents un-scalable images from repeatedly showing up in the bulk scan and/or scheduled optimization queue.