### PR TITLE
store webp size and error code

### DIFF
--- a/classes/class-ewww-image.php
+++ b/classes/class-ewww-image.php
@@ -143,6 +143,20 @@ class EWWW_Image {
 	public $resized_width = 0;
 
 	/**
+	 * The size of the corresponding WebP image, if it exists.
+	 *
+	 * @var int $webp_size
+	 */
+	public $webp_size = 0;
+
+	/**
+	 * An error code from WebP conversion.
+	 *
+	 * @var int $webp_error
+	 */
+	public $webp_error = 0;
+
+	/**
 	 * A retrieval ID for an API-optimized image that hasn't yet completed.
 	 *
 	 * @var string $retrieve
@@ -245,18 +259,23 @@ class EWWW_Image {
 		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_debug' ) && ewww_image_optimizer_function_exists( 'print_r' ) ) {
 			ewwwio_debug_message( print_r( $new_image, true ) );
 		}
-		$this->id            = $new_image['id'];
-		$this->file          = ewww_image_optimizer_absolutize_path( $new_image['path'] );
-		$this->attachment_id = (int) $new_image['attachment_id'];
-		$this->opt_size      = (int) $new_image['image_size'];
-		$this->orig_size     = (int) $new_image['orig_size'];
-		$this->resize        = $new_image['resize'];
-		$this->converted     = ewww_image_optimizer_absolutize_path( $new_image['converted'] );
-		$this->gallery       = ( empty( $gallery ) || empty( $new_image['attachment_id'] ) ? $new_image['gallery'] : $gallery );
-		$this->backup        = $new_image['backup'];
-		$this->retrieve      = $new_image['retrieve'];
-		$this->level         = (int) $new_image['level'];
-		$this->record        = $new_image;
+		$this->id             = $new_image['id'];
+		$this->file           = ewww_image_optimizer_absolutize_path( $new_image['path'] );
+		$this->attachment_id  = (int) $new_image['attachment_id'];
+		$this->opt_size       = (int) $new_image['image_size'];
+		$this->orig_size      = (int) $new_image['orig_size'];
+		$this->resize         = $new_image['resize'];
+		$this->converted      = ewww_image_optimizer_absolutize_path( $new_image['converted'] );
+		$this->resized_width  = (int) $new_image['resized_width'];
+		$this->resized_height = (int) $new_image['resized_height'];
+		$this->resize_error   = (int) $new_image['resize_error'];
+		$this->webp_size      = (int) $new_image['webp_size'];
+		$this->webp_error     = (int) $new_image['webp_error'];
+		$this->gallery        = ( empty( $gallery ) || empty( $new_image['attachment_id'] ) ? $new_image['gallery'] : $gallery );
+		$this->backup         = $new_image['backup'];
+		$this->retrieve       = $new_image['retrieve'];
+		$this->level          = (int) $new_image['level'];
+		$this->record         = $new_image;
 	}
 
 	/**

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -13,7 +13,7 @@ Plugin Name: EWWW Image Optimizer
 Plugin URI: https://wordpress.org/plugins/ewww-image-optimizer/
 Description: Smaller Images, Faster Sites, Happier Visitors. Comprehensive image optimization that doesn't require a degree in rocket science.
 Author: Exactly WWW
-Version: 7.3.0
+Version: 7.3.0.1
 Requires at least: 6.1
 Requires PHP: 7.3
 Author URI: https://ewww.io/
@@ -34,7 +34,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70300 ) {
 	add_action( 'admin_notices', 'ewww_image_optimizer_dual_plugin' );
 } elseif ( false === strpos( add_query_arg( '', '' ), 'ewwwio_disable=1' ) ) {
 
-	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 730 );
+	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 730.1 );
 
 	if ( WP_DEBUG && function_exists( 'memory_get_usage' ) ) {
 		$ewww_memory = 'plugin load: ' . memory_get_usage( true ) . "\n";

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,11 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 * Feature requests can be viewed and submitted on our [feedback portal](https://feedback.ewww.io/b/features)
 * If you would like to help translate this plugin in your language, [join the team](https://translate.wordpress.org/projects/wp-plugins/ewww-image-optimizer/)
 
+= 7.3.1 =
+*Release Date - TBD*
+
+* added: store WebP results/errors for display in Media Library
+
 = 7.3.0 =
 *Release Date - February 20, 2024*
 


### PR DESCRIPTION
This allows for later display of WebP errors in the media library, and in the optimized images table. Also added the resize status to the optimized images table.