### PR TITLE
If there is no file, no need to do all the other checks

### DIFF
--- a/common.php
+++ b/common.php
@@ -3665,6 +3665,9 @@ function ewwwio_is_file( $file ) {
 	global $eio_filesystem;
 	ewwwio_get_filesystem();
 	$file       = realpath( $file );
+	if ( ! $file ) {
+		return false;
+	}
 	$wp_dir     = realpath( ABSPATH );
 	$upload_dir = wp_get_upload_dir();
 	$upload_dir = realpath( $upload_dir['basedir'] );


### PR DESCRIPTION
I found that this fix speeds up page loads considerably.
The conditions are strange;
EWWW has WebP conversion disabled, yet, EWWW searches for the WebP variant of all images on a page.
Don't know why yet, but at this time, `realpath( $file )` is false as the WebP file does not exist, and all the other checks are no longer relevant.
In my situation, this sped up the page load from 4.27 seconds to 1.37 seconds, consistently over 20 tests.
