### PR TITLE
fixed async get status error handling

### DIFF
--- a/bulk.php
+++ b/bulk.php
@@ -992,17 +992,17 @@ function ewww_image_optimizer_bulk_async_init() {
 	if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
 		$verify_cloud = ewww_image_optimizer_cloud_verify( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ), false );
 		if ( 'exceeded' === $verify_cloud ) {
-			$output['media_remaining'] = ewww_image_optimizer_credits_exceeded();
+			$output['error'] = ewww_image_optimizer_credits_exceeded();
 			ewwwio_ob_clean();
 			die( wp_json_encode( $output ) );
 		}
 		if ( 'exceeded quota' === $verify_cloud ) {
-			$output['media_remaining'] = ewww_image_optimizer_soft_quota_exceeded();
+			$output['error'] = ewww_image_optimizer_soft_quota_exceeded();
 			ewwwio_ob_clean();
 			die( wp_json_encode( $output ) );
 		}
 		if ( 'exceeded subkey' === $verify_cloud ) {
-			$output['media_remaining'] = esc_html__( 'Out of credits', 'ewww-image=optimizer' );
+			$output['error'] = esc_html__( 'Out of credits', 'ewww-image=optimizer' );
 			ewwwio_ob_clean();
 			die( wp_json_encode( $output ) );
 		}

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -34,7 +34,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70300 ) {
 	add_action( 'admin_notices', 'ewww_image_optimizer_dual_plugin' );
 } elseif ( false === strpos( add_query_arg( '', '' ), 'ewwwio_disable=1' ) ) {
 
-	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 780.1 );
+	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 780.31 );
 
 	if ( WP_DEBUG && function_exists( 'memory_get_usage' ) ) {
 		$ewww_memory = 'plugin load: ' . memory_get_usage( true ) . "\n";

--- a/includes/eio-bulk-table.js
+++ b/includes/eio-bulk-table.js
@@ -104,6 +104,7 @@ jQuery(document).ready(function($) {
 			}
 			if ( ewww_response.error ) {
 				$('#ewww-optimize-local-images').html('<span class="ewww-bulk-error"><b>' + ewww_response.error + '</b></span>');
+				$('.ewww-bulk-spinner').hide();
 			} else if ( ewww_response.media_remaining ) {
 				$('.ewww-bulk-spinner').show();
 				$('#ewww-optimize-local-images').html( ewww_response.media_remaining );
@@ -181,7 +182,9 @@ jQuery(document).ready(function($) {
 			} else {
 				$('.ewww-queue-controls').hide();
 				$('.ewww-bulk-spinner').hide();
-				if (ewww_response.complete) {
+				if (ewww_response.error) {
+					$('#ewww-optimize-local-images').html('<span class="ewww-bulk-error"><b>' + ewww_response.error + '</b></span>');
+				} else if (ewww_response.complete) {
 					if (ewww_table_visible) {
 						ewwwUpdateTable();
 					}

--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,9 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 *Release Date - TBD*
 * changed: allow folders outside of WordPress install to be optimized via Folders to Optimize
 * changed: improve performance of ewwwio_is_file(), props @rmpel
+* changed: improve exceeded credit messages for sub-keys
+* fixed: bulk async shows start optimizing instead of resume when queues are paused
+* fixed: bulk async status refresh does not handle errors properly
 
 = 7.8.0 =
 *Release Date - July 25, 2024*


### PR DESCRIPTION
The JS handler did not check for an error, so that is fixed. Also, on bulk async initialization, return an error for credits exceeded instead of just a normal message to prevent auto-poll from starting.