### PR TITLE
remove ewwwdb and rework mass_insert

### DIFF
--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -278,7 +278,6 @@ class Backup extends Base {
 	 * Restore an image from local or cloud storage.
 	 *
 	 * @global object $wpdb
-	 * @global object $ewwwdb A clone of $wpdb unless it is lacking utf8 connectivity.
 	 *
 	 * @param int|array $image The db record/ID of the image to restore.
 	 * @return bool True if the image was restored successfully.
@@ -286,17 +285,11 @@ class Backup extends Base {
 	public function restore_file( $image ) {
 		$this->debug_message( '<b>' . __METHOD__ . '()</b>' );
 		global $wpdb;
-		if ( \strpos( $wpdb->charset, 'utf8' ) === false ) {
-			\ewww_image_optimizer_db_init();
-			global $ewwwdb;
-		} else {
-			$ewwwdb = $wpdb;
-		}
 		$this->error_message = '';
 		if ( ! \is_array( $image ) && ! empty( $image ) && \is_numeric( $image ) ) {
-			$image = $ewwwdb->get_row(
-				$ewwwdb->prepare(
-					"SELECT id,path,backup FROM $ewwwdb->ewwwio_images WHERE id = %d",
+			$image = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT id,path,backup FROM $wpdb->ewwwio_images WHERE id = %d",
 					$image
 				),
 				ARRAY_A
@@ -418,7 +411,6 @@ class Backup extends Base {
 	 * Restore an attachment from the API or local backups.
 	 *
 	 * @global object $wpdb
-	 * @global object $ewwwdb A clone of $wpdb unless it is lacking utf8 connectivity.
 	 *
 	 * @param int    $id The attachment id number.
 	 * @param string $gallery Optional. The gallery from whence we came. Default 'media'.
@@ -428,15 +420,9 @@ class Backup extends Base {
 	public function restore_backup_from_meta_data( $id, $gallery = 'media', $meta = array() ) {
 		$this->debug_message( '<b>' . __METHOD__ . '()</b>' );
 		global $wpdb;
-		if ( \strpos( $wpdb->charset, 'utf8' ) === false ) {
-			\ewww_image_optimizer_db_init();
-			global $ewwwdb;
-		} else {
-			$ewwwdb = $wpdb;
-		}
-		$images = $ewwwdb->get_results(
-			$ewwwdb->prepare(
-				"SELECT id,path,resize,backup FROM $ewwwdb->ewwwio_images WHERE attachment_id = %d AND gallery = %s",
+		$images = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id,path,resize,backup FROM $wpdb->ewwwio_images WHERE attachment_id = %d AND gallery = %s",
 				$id,
 				$gallery
 			),

--- a/classes/class-ewwwio-cli.php
+++ b/classes/class-ewwwio-cli.php
@@ -286,12 +286,6 @@ class EWWWIO_CLI extends WP_CLI_Command {
 		}
 		global $eio_backup;
 		global $wpdb;
-		if ( strpos( $wpdb->charset, 'utf8' ) === false ) {
-			ewww_image_optimizer_db_init();
-			global $ewwwdb;
-		} else {
-			$ewwwdb = $wpdb;
-		}
 
 		$completed = 0;
 		$position  = (int) get_option( 'ewww_image_optimizer_bulk_restore_position' );
@@ -424,12 +418,6 @@ class EWWWIO_CLI extends WP_CLI_Command {
 			delete_option( 'ewww_image_optimizer_delete_originals_resume' );
 		}
 		global $wpdb;
-		if ( strpos( $wpdb->charset, 'utf8' ) === false ) {
-			ewww_image_optimizer_db_init();
-			global $ewwwdb;
-		} else {
-			$ewwwdb = $wpdb;
-		}
 
 		$per_page = 200;
 
@@ -501,12 +489,6 @@ class EWWWIO_CLI extends WP_CLI_Command {
 			delete_option( 'ewww_image_optimizer_webp_clean_position' );
 		}
 		global $wpdb;
-		if ( strpos( $wpdb->charset, 'utf8' ) === false ) {
-			ewww_image_optimizer_db_init();
-			global $ewwwdb;
-		} else {
-			$ewwwdb = $wpdb;
-		}
 
 		$completed = 0;
 		$per_page  = 200;

--- a/classes/class-ewwwio-relative-migration.php
+++ b/classes/class-ewwwio-relative-migration.php
@@ -65,16 +65,12 @@ class EWWWIO_Relative_Migration {
 	 */
 	private function get_records() {
 		ewwwio_debug_message( '<b>' . __METHOD__ . '()</b>' );
+
 		global $wpdb;
-		if ( strpos( $wpdb->charset, 'utf8' ) === false ) {
-			ewww_image_optimizer_db_init();
-			global $ewwwdb;
-		} else {
-			$ewwwdb = $wpdb;
-		}
-		$records = $ewwwdb->get_results(
-			$ewwwdb->prepare(
-				"SELECT id,path,updated FROM $ewwwdb->ewwwio_images WHERE pending=0 AND image_size > 0 ORDER BY id DESC LIMIT %d,500",
+
+		$records = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id,path,updated FROM $wpdb->ewwwio_images WHERE pending=0 AND image_size > 0 ORDER BY id DESC LIMIT %d,500",
 				$this->offset
 			),
 			ARRAY_A
@@ -146,14 +142,8 @@ class EWWWIO_Relative_Migration {
 	private function update_relative_record( $record ) {
 		ewwwio_debug_message( '<b>' . __METHOD__ . '()</b>' );
 		global $wpdb;
-		if ( strpos( $wpdb->charset, 'utf8' ) === false ) {
-			ewww_image_optimizer_db_init();
-			global $ewwwdb;
-		} else {
-			$ewwwdb = $wpdb;
-		}
-		$ewwwdb->update(
-			$ewwwdb->ewwwio_images,
+		$wpdb->update(
+			$wpdb->ewwwio_images,
 			array(
 				'path'    => $record['path'],
 				'updated' => $record['updated'],

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -13,7 +13,7 @@ Plugin Name: EWWW Image Optimizer
 Plugin URI: https://wordpress.org/plugins/ewww-image-optimizer/
 Description: Smaller Images, Faster Sites, Happier Visitors. Comprehensive image optimization that doesn't require a degree in rocket science.
 Author: Exactly WWW
-Version: 7.8.0.4
+Version: 7.8.0.6
 Requires at least: 6.3
 Requires PHP: 7.3
 Author URI: https://ewww.io/
@@ -34,7 +34,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70300 ) {
 	add_action( 'admin_notices', 'ewww_image_optimizer_dual_plugin' );
 } elseif ( false === strpos( add_query_arg( '', '' ), 'ewwwio_disable=1' ) ) {
 
-	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 780.4 );
+	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 780.6 );
 
 	if ( WP_DEBUG && function_exists( 'memory_get_usage' ) ) {
 		$ewww_memory = 'plugin load: ' . memory_get_usage( true ) . "\n";

--- a/readme.txt
+++ b/readme.txt
@@ -146,8 +146,11 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 * changed: allow folders outside of WordPress install to be optimized via Folders to Optimize
 * changed: improve performance of ewwwio_is_file(), props @rmpel
 * changed: improve exceeded credit messages for sub-keys
+* changed: warn when db connection is not using UTF-8
+* changed: ensure all db statements are properly prepared/sanitized
 * fixed: bulk async shows start optimizing instead of resume when queues are paused
 * fixed: bulk async status refresh does not handle errors properly
+* fixed: some strings with i18n had incorrect text domain
 
 = 7.8.0 =
 *Release Date - July 25, 2024*


### PR DESCRIPTION
Removed all usage of ewwwdb, replaced with standard wpdb. This required reworking some functions to better validate usage of wpdb->prepare(). The ewww_image_optimizer_mass_insert() function explicitly does not use wpdb->prepare() in order to speed up large insert queries. Added a notice that folks without UTF8 connections may have issues with non-English filenames.