### PR TITLE
implement sharpening for webp resizing from original

### DIFF
--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -594,7 +594,7 @@ class Base {
 				$this->debug_message( 'sorry nope' );
 			}
 		}
-		return $this->imagick_supports_webp;
+		return apply_filters( 'ewwwio_imagick_supports_webp', $this->imagick_supports_webp );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -147,9 +147,15 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 = 8.0.1 =
 *Release Date - TBD*
 
+* added: Preserve Originals option to keep pre-scaled images for WebP and thumbnail generation
 * added: ability for 3rd party plugins to hook into Lazy Load and WebP HTML parsers
 * changed: improved performance of custom *_option functions on multisite
+* changed: Max Image Dimensions always override WP big_image threshold
+* changed: ImageMagick is default WebP conversion method on supported servers
+* changed: local image backups not removed on plugin deactivation
+* fixed: Sharpen Images not applied to new WebP Conversion process
 * fixed: WebP resizing overrides custom crop set by Crop Thumbnails
+* fixed: pre-scaled original cannot be found if attachment metadata is incomplete
 
 = 8.0.0 =
 *Release Date - December 11, 2024*

--- a/unique.php
+++ b/unique.php
@@ -1322,15 +1322,17 @@ function ewww_image_optimizer_webp_create( $file, $orig_size, $type, $tool, $rec
 		return ewww_image_optimizer_webp_error_message( 4 );
 	}
 	if ( empty( $tool ) || 'image/gif' === $type ) {
-		if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-			ewww_image_optimizer_cloud_optimizer( $file, $type, false, $webpfile, 'image/webp' );
-		} elseif ( ewwwio()->imagick_supports_webp() ) {
+		if ( ewwwio()->imagick_supports_webp() ) {
 			ewww_image_optimizer_imagick_create_webp( $file, $type, $webpfile );
+		} elseif ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) {
+			ewww_image_optimizer_cloud_optimizer( $file, $type, false, $webpfile, 'image/webp' );
 		} elseif ( ewwwio()->gd_supports_webp() ) {
 			ewww_image_optimizer_gd_create_webp( $file, $type, $webpfile );
 		} else {
 			ewww_image_optimizer_cloud_optimizer( $file, $type, false, $webpfile, 'image/webp' );
 		}
+	} elseif ( ewwwio()->imagick_supports_webp() ) {
+			ewww_image_optimizer_imagick_create_webp( $file, $type, $webpfile );
 	} else {
 		$nice = '';
 		if ( PHP_OS !== 'WINNT' && ! ewwwio()->cloud_mode && ewwwio()->local->exec_check() ) {


### PR DESCRIPTION
Changed Imagick to be default WebP generation method on supported servers. Changed EWWWIO_Imagick_Editor to no longer use parent _save() method, so that sharp_yuv can be applied along with CMYK conversion and color profile handling.