### PR TITLE
Imagick/editor webp quality

### DIFF
--- a/classes/class-ewwwio-imagick-editor.php
+++ b/classes/class-ewwwio-imagick-editor.php
@@ -755,6 +755,10 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 					$this->image->setImageProfile( '*', null );
 					$profiles = array();
 				}
+				$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
+				\ewwwio_debug_message( "setting image/webp quality to $quality (post-color check)" );
+				$this->image->setImageCompressionQuality( $quality );
+				$this->image->setCompressionQuality( $quality );
 			}
 
 			$this->image->setImageFormat( strtoupper( $this->get_extension( $mime_type ) ) );
@@ -764,6 +768,10 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 					\ewwwio_debug_message( 'enabling sharp_yuv' );
 					$this->image->setOption( 'webp:use-sharp-yuv', 'true' );
 				}
+				$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
+				\ewwwio_debug_message( "setting image/webp quality to $quality (post-sharp)" );
+				$this->image->setImageCompressionQuality( $quality );
+				$this->image->setCompressionQuality( $quality );
 
 				if ( \ewww_image_optimizer_get_option( 'ewww_image_optimizer_metadata_remove' ) ) {
 					\ewwwio_debug_message( 'removing meta' );
@@ -773,6 +781,11 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 						$this->image->profileImage( 'icc', $profiles['icc'] );
 					}
 				}
+				$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
+				\ewwwio_debug_message( "setting image/webp quality to $quality (post-meta)" );
+				$this->image->setImageCompressionQuality( $quality );
+				$this->image->setCompressionQuality( $quality );
+
 			}
 		} catch ( Exception $e ) {
 			return new WP_Error( 'image_save_error', $e->getMessage(), $filename );
@@ -792,6 +805,12 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 			}
 		}
 
+		if ( 'image/webp' === $mime_type ) {
+			$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
+			\ewwwio_debug_message( "setting image/webp quality to $quality (pre-write)" );
+			$this->image->setImageCompressionQuality( $quality );
+			$this->image->setCompressionQuality( $quality );
+		}
 		$write_image_result = $this->write_image( $this->image, $filename );
 		if ( is_wp_error( $write_image_result ) ) {
 			return $write_image_result;

--- a/classes/class-ewwwio-imagick-editor.php
+++ b/classes/class-ewwwio-imagick-editor.php
@@ -755,10 +755,6 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 					$this->image->setImageProfile( '*', null );
 					$profiles = array();
 				}
-				$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
-				\ewwwio_debug_message( "setting image/webp quality to $quality (post-color check)" );
-				$this->image->setImageCompressionQuality( $quality );
-				$this->image->setCompressionQuality( $quality );
 			}
 
 			$this->image->setImageFormat( strtoupper( $this->get_extension( $mime_type ) ) );
@@ -768,10 +764,6 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 					\ewwwio_debug_message( 'enabling sharp_yuv' );
 					$this->image->setOption( 'webp:use-sharp-yuv', 'true' );
 				}
-				$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
-				\ewwwio_debug_message( "setting image/webp quality to $quality (post-sharp)" );
-				$this->image->setImageCompressionQuality( $quality );
-				$this->image->setCompressionQuality( $quality );
 
 				if ( \ewww_image_optimizer_get_option( 'ewww_image_optimizer_metadata_remove' ) ) {
 					\ewwwio_debug_message( 'removing meta' );
@@ -781,11 +773,6 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 						$this->image->profileImage( 'icc', $profiles['icc'] );
 					}
 				}
-				$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
-				\ewwwio_debug_message( "setting image/webp quality to $quality (post-meta)" );
-				$this->image->setImageCompressionQuality( $quality );
-				$this->image->setCompressionQuality( $quality );
-
 			}
 		} catch ( Exception $e ) {
 			return new WP_Error( 'image_save_error', $e->getMessage(), $filename );
@@ -805,12 +792,6 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 			}
 		}
 
-		if ( 'image/webp' === $mime_type ) {
-			$quality = (int) apply_filters( 'webp_quality', 75, 'image/webp' );
-			\ewwwio_debug_message( "setting image/webp quality to $quality (pre-write)" );
-			$this->image->setImageCompressionQuality( $quality );
-			$this->image->setCompressionQuality( $quality );
-		}
 		$write_image_result = $this->write_image( $this->image, $filename );
 		if ( is_wp_error( $write_image_result ) ) {
 			return $write_image_result;

--- a/common.php
+++ b/common.php
@@ -3052,13 +3052,11 @@ function ewww_image_optimizer_imagick_create_webp( $file, $type, $webpfile ) {
 					$error_message = $editor->get_error_message();
 					ewwwio_debug_message( "could not get image editor: $error_message" );
 				} else {
-					$editor->set_quality( $quality );
 					$resized_image = $editor->resize( $webp_width, $webp_height, $webp_crop );
 					if ( is_wp_error( $resized_image ) ) {
 						$error_message = $resized_image->get_error_message();
 						ewwwio_debug_message( "error during resizing: $error_message" );
 					} else {
-						$editor->set_quality( $quality );
 						$saved = $editor->save( $webpfile, 'image/webp' );
 						if ( is_wp_error( $saved ) ) {
 							$error_message = $saved->get_error_message();

--- a/common.php
+++ b/common.php
@@ -60,6 +60,8 @@ add_filter( 'jpeg_quality', 'ewww_image_optimizer_set_jpg_quality', PHP_INT_MAX 
 add_filter( 'webp_quality', 'ewww_image_optimizer_set_webp_quality' );
 // Allows the user to override the default AVIF quality used by EWWW IO.
 add_filter( 'avif_quality', 'ewww_image_optimizer_set_avif_quality' );
+// Allows the user to override the default image editor quality used by WP_Image_Editor and friends.
+add_filter( 'wp_editor_set_quality', 'ewww_image_optimizer_editor_set_quality', 10, 2 );
 // Prevent WP from over-riding EWWW IO's resize settings.
 add_filter( 'big_image_size_threshold', '__return_false' );
 // Makes sure the plugin bypasses any files affected by the Folders to Ignore setting.
@@ -3050,11 +3052,13 @@ function ewww_image_optimizer_imagick_create_webp( $file, $type, $webpfile ) {
 					$error_message = $editor->get_error_message();
 					ewwwio_debug_message( "could not get image editor: $error_message" );
 				} else {
+					$editor->set_quality( $quality );
 					$resized_image = $editor->resize( $webp_width, $webp_height, $webp_crop );
 					if ( is_wp_error( $resized_image ) ) {
 						$error_message = $resized_image->get_error_message();
 						ewwwio_debug_message( "error during resizing: $error_message" );
 					} else {
+						$editor->set_quality( $quality );
 						$saved = $editor->save( $webpfile, 'image/webp' );
 						if ( is_wp_error( $saved ) ) {
 							$error_message = $saved->get_error_message();
@@ -3064,7 +3068,7 @@ function ewww_image_optimizer_imagick_create_webp( $file, $type, $webpfile ) {
 				}
 				$ewww_preempt_editor = $original_preempt;
 				if ( ewwwio_is_file( $webpfile ) ) {
-					ewwwio_debug_message( "$webpfile exists, calling it a day" );
+					ewwwio_debug_message( "$webpfile exists, generation via wp_image_editor succeeded" );
 					return;
 				}
 				ewwwio_debug_message( 'something unknown went wrong, try the normal process' );
@@ -3481,6 +3485,25 @@ function ewww_image_optimizer_avif_quality( $quality = null ) {
  */
 function ewww_image_optimizer_set_avif_quality( $quality ) {
 	$new_quality = ewww_image_optimizer_avif_quality();
+	if ( ! empty( $new_quality ) ) {
+		return min( 92, $new_quality );
+	}
+	return min( 92, $quality );
+}
+
+/**
+ * Overrides the default quality (if a user-defined value is set).
+ *
+ * @param int    $quality The default image editor quality level.
+ * @param string $mime_type The type of file being output.
+ * @return int The default quality, or the user configured level.
+ */
+function ewww_image_optimizer_editor_set_quality( $quality, $mime_type = '' ) {
+	if ( empty( $mime_type ) || 'image/jpeg' === $mime_type ) {
+		$new_quality = ewww_image_optimizer_jpg_quality();
+	} elseif ( 'image/webp' === $mime_type ) {
+		$new_quality = ewww_image_optimizer_webp_quality();
+	}
 	if ( ! empty( $new_quality ) ) {
 		return min( 92, $new_quality );
 	}


### PR DESCRIPTION
Implemented a filter function on wp_editor_set_quality to ensure that the new WebP generation via Imagick is using the WebP quality configured in EWWW IO.