### PR TITLE
make id fields into bigint and fix upgrade for id column

### DIFF
--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -34,7 +34,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70400 ) {
 	add_action( 'admin_notices', 'ewww_image_optimizer_dual_plugin' );
 } elseif ( false === strpos( add_query_arg( '', '' ), 'ewwwio_disable=1' ) ) {
 
-	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 810 );
+	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 810.13 );
 
 	if ( WP_DEBUG && function_exists( 'memory_get_usage' ) ) {
 		$ewww_memory = 'plugin load: ' . memory_get_usage( true ) . "\n";


### PR DESCRIPTION
Since dbDelta() cannot properly add an new primary key column, we check first to see if the 'id' column exists. If it doesn't, create it manually before dbDelta() runs.
This also bumps both id columns to bigint for future-proofing.