### PR TITLE
various bulk scanner and webp improvements

### DIFF
--- a/classes/class-background-process.php
+++ b/classes/class-background-process.php
@@ -447,7 +447,7 @@ abstract class Background_Process extends Async_Request {
 		if ( empty( $batch ) ) {
 			return array();
 		}
-		\ewwwio_debug_message( 'selected items: ' . count( $batch ) );
+		\ewwwio_debug_message( "selected items for {$this->active_queue}: " . count( $batch ) );
 
 		$this->update_lock();
 		return $batch;

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -748,6 +748,7 @@ final class Plugin extends Base {
 		register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_pdf_level', 'intval' );
 		register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_svg_level', 'intval' );
 		register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_webp_level', 'intval' );
+		register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_webp_conversion_method', 'sanitize_text_field' );
 		register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_backup_files', 'sanitize_text_field' );
 		register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_sharpen', 'boolval' );
 		register_setting( 'ewww_image_optimizer_options', 'ewww_image_optimizer_jpg_quality', 'ewww_image_optimizer_jpg_quality' );
@@ -819,6 +820,7 @@ final class Plugin extends Base {
 		\add_option( 'ewww_image_optimizer_pdf_level', '0' );
 		\add_option( 'ewww_image_optimizer_svg_level', '0' );
 		\add_option( 'ewww_image_optimizer_webp_level', '0' );
+		\add_option( 'ewww_image_optimizer_webp_conversion_method', 'local' );
 		\add_option( 'ewww_image_optimizer_webp', false );
 		\add_option( 'ewww_image_optimizer_jpg_quality', '' );
 		\add_option( 'ewww_image_optimizer_webp_quality', '' );
@@ -860,6 +862,7 @@ final class Plugin extends Base {
 		\add_site_option( 'ewww_image_optimizer_pdf_level', '0' );
 		\add_site_option( 'ewww_image_optimizer_svg_level', '0' );
 		\add_site_option( 'ewww_image_optimizer_webp_level', '0' );
+		\add_site_option( 'ewww_image_optimizer_webp_conversion_method', 'local' );
 		\add_site_option( 'ewww_image_optimizer_jpg_quality', '' );
 		\add_site_option( 'ewww_image_optimizer_webp_quality', '' );
 		\add_site_option( 'ewww_image_optimizer_backup_files', '' );

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -34,7 +34,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70400 ) {
 	add_action( 'admin_notices', 'ewww_image_optimizer_dual_plugin' );
 } elseif ( false === strpos( add_query_arg( '', '' ), 'ewwwio_disable=1' ) ) {
 
-	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 811.2 );
+	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 811.34 );
 
 	if ( WP_DEBUG && function_exists( 'memory_get_usage' ) ) {
 		$ewww_memory = 'plugin load: ' . memory_get_usage( true ) . "\n";

--- a/readme.txt
+++ b/readme.txt
@@ -147,8 +147,13 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 = 8.1.2 =
 *Release Date - TBD*
 
+* changed: WebP Conversion mode configurable for API users
+* changed: combine metadata queries for faster async scanning
 * fixed: background processes trigger notice from loading translations too early
 * fixed: WooCommerce thumb regen still runs when WC sizes are disabled
+* fixed: Easy IO fails to refresh CDN domain when site URL has changed
+* fixed: Force and WebP Only options not applied when scanning additional folders in async mode
+* fixed: PDF and SVG images queued in WebP Only mode
 
 = 8.1.1 =
 *Release Date - February 26, 2025*


### PR DESCRIPTION
Prevent ineligible images/files being queued in webp-only mode.
Ensure bulk options like WebP-only and Force-* are passed to async scanner for extra/aux folders.
Add Cloud/Local toggle for WebP conversion mode.
Combine/cache metadata queries in async media process for faster scanning.