### PR TITLE
Jpg only mode improvements

### DIFF
--- a/aux-optimize.php
+++ b/aux-optimize.php
@@ -1759,10 +1759,7 @@ function ewww_image_optimizer_image_scan( $dir, $started = 0 ) {
 	}
 
 	$supported_types = ewwwio()->get_supported_types();
-	$webp_types      = array( 'image/jpeg', 'image/png' );
-	if ( ewwwio()->get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-		$webp_types[] = 'image/gif';
-	}
+	$webp_types      = ewwwio()->get_webp_types();
 
 	foreach ( $iterator as $file ) {
 		if ( get_transient( 'ewww_image_optimizer_aux_iterator' ) && get_transient( 'ewww_image_optimizer_aux_iterator' ) > $file_counter ) {

--- a/bulk.php
+++ b/bulk.php
@@ -1457,10 +1457,7 @@ function ewww_image_optimizer_media_scan( $hook = '' ) {
 	$disabled_sizes = ewww_image_optimizer_get_option( 'ewww_image_optimizer_disable_resizes_opt', false, true );
 
 	$supported_types = ewwwio()->get_supported_types();
-	$webp_types      = array( 'image/jpeg', 'image/png' );
-	if ( ewwwio()->get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-		$webp_types[] = 'image/gif';
-	}
+	$webp_types      = ewwwio()->get_webp_types();
 
 	ewww_image_optimizer_debug_log();
 	$starting_memory_usage = memory_get_usage( true );

--- a/classes/class-background-process-media.php
+++ b/classes/class-background-process-media.php
@@ -199,10 +199,7 @@ class Background_Process_Media extends Background_Process {
 			return false;
 		}
 		$mime       = ewww_image_optimizer_quick_mimetype( $file_path );
-		$webp_types = array( 'image/jpeg', 'image/png' );
-		if ( ewwwio()->get_option( 'ewww_image_optimizer_cloud_key' ) ) {
-			$webp_types[] = 'image/gif';
-		}
+		$webp_types = ewwwio()->get_webp_types();
 		if ( $item['webp_only'] && ! in_array( $mime, $webp_types, true ) ) {
 			\ewwwio_debug_message( "not eligible for WebP conversion: $file_path" );
 			return false;

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -638,6 +638,22 @@ class Base {
 	}
 
 	/**
+	 * Get a list of which image types can be converted to WebP with the current configuration.
+	 *
+	 * @return A list of mime-types suitable for WebP conversion.
+	 */
+	public function get_webp_types() {
+		$webp_types = array( 'image/jpeg' );
+		if ( $this->get_option( 'ewww_image_optimizer_cloud_key' ) ) {
+			$webp_types[] = 'image/png';
+			$webp_types[] = 'image/gif';
+		} elseif ( ! $this->get_option( 'ewww_image_optimizer_jpg_only_mode' ) ) {
+			$webp_types[] = 'image/png';
+		}
+		return $webp_types;
+	}
+
+	/**
 	 * Checks if the S3 Uploads plugin is installed and active.
 	 *
 	 * @return bool True if it is fully active and rewriting/offloading media, false otherwise.

--- a/classes/class-js-webp.php
+++ b/classes/class-js-webp.php
@@ -1073,6 +1073,9 @@ class JS_Webp extends Page_Parser {
 			return false;
 		}
 		if ( $this->get_option( 'ewww_image_optimizer_webp_force' ) && $this->is_iterable( $this->allowed_urls ) ) {
+			if ( $extension && 'png' === $extension && $this->get_option( 'ewww_image_optimizer_jpg_only_mode' ) ) {
+				return false;
+			}
 			// Check the image for configured CDN paths.
 			foreach ( $this->allowed_urls as $allowed_url ) {
 				if ( \strpos( $image, $allowed_url ) !== false ) {

--- a/classes/class-picture-webp.php
+++ b/classes/class-picture-webp.php
@@ -565,6 +565,9 @@ class Picture_Webp extends Page_Parser {
 			return false;
 		}
 		if ( $this->get_option( 'ewww_image_optimizer_webp_force' ) && $this->is_iterable( $this->allowed_urls ) ) {
+			if ( $extension && 'png' === $extension && $this->get_option( 'ewww_image_optimizer_jpg_only_mode' ) ) {
+				return false;
+			}
 			// Check the image for configured CDN paths.
 			foreach ( $this->allowed_urls as $allowed_url ) {
 				if ( \strpos( $image, $allowed_url ) !== false ) {

--- a/common.php
+++ b/common.php
@@ -5605,7 +5605,7 @@ function ewww_image_optimizer_cloud_optimizer( $file, $type, $convert = false, $
 	) {
 		$free_exec = true;
 	}
-	if ( ! $free_exec && $webp ) {
+	if ( ! $free_exec && $webp && 'image/jpeg' === $type ) {
 		$free_exec = true;
 	}
 	if ( empty( $api_key ) && ! $free_exec ) {
@@ -14043,6 +14043,11 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 							</p>
 		<?php endif; ?>
 		<?php if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) : ?>
+			<?php if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_only_mode' ) ) : ?>
+							<p class='description'>
+								*<?php esc_html_e( 'PNG to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
+							</p>
+			<?php endif; ?>
 							<p class='description'>
 								*<?php esc_html_e( 'GIF to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
 							</p>
@@ -14270,12 +14275,21 @@ AddType image/webp .webp</pre>
 									<?php esc_html_e( 'Click to enable forced GIF rewriting once WebP version have been generated.', 'ewww-image-optimizer' ); ?>
 								</a>
 							</p>
-			<?php elseif ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_webp_force' ) && ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_force_gif2webp' ) && ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) : ?>
+			<?php elseif ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_webp_force' ) && ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) : ?>
+				<?php if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_only_mode' ) ) : ?>
 							<p class='description'>
 								<a href="https://ewww.io/plans/" target="_blank">
-									<?php esc_html_e( 'GIF to WebP conversion requires an API key.', 'ewww-image-optimizer' ); ?>
+									<?php esc_html_e( 'PNG to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
 								</a>
 							</p>
+				<?php endif; ?>
+				<?php if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_force_gif2webp' ) ) : ?>
+							<p class='description'>
+								<a href="https://ewww.io/plans/" target="_blank">
+									<?php esc_html_e( 'GIF to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
+								</a>
+							</p>
+				<?php endif; ?>
 			<?php endif; ?>
 						</div>
 					</div>

--- a/common.php
+++ b/common.php
@@ -14043,13 +14043,17 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 							</p>
 		<?php endif; ?>
 		<?php if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) : ?>
+							<p>&nbsp;</p>
 			<?php if ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_only_mode' ) ) : ?>
 							<p class='description'>
-								*<?php esc_html_e( 'PNG to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
+								<?php esc_html_e( 'PNG to WebP conversion requires an API key because your web server does not meet the requirements for free PNG compression.', 'ewww-image-optimizer' ); ?>
+								<?php ewwwio_help_link( 'https://docs.ewww.io/article/29-what-is-exec-and-why-do-i-need-it', '592dd12d0428634b4a338c39' ); ?>
 							</p>
 			<?php endif; ?>
 							<p class='description'>
-								*<?php esc_html_e( 'GIF to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
+								<a href="https://ewww.io/plans/" target="_blank">
+									<?php esc_html_e( 'GIF to WebP conversion requires an API key.', 'ewww-image-optimizer' ); ?>
+								</a>
 							</p>
 		<?php endif; ?>
 						</div>
@@ -14275,21 +14279,6 @@ AddType image/webp .webp</pre>
 									<?php esc_html_e( 'Click to enable forced GIF rewriting once WebP version have been generated.', 'ewww-image-optimizer' ); ?>
 								</a>
 							</p>
-			<?php elseif ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_webp_force' ) && ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_cloud_key' ) ) : ?>
-				<?php if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_jpg_only_mode' ) ) : ?>
-							<p class='description'>
-								<a href="https://ewww.io/plans/" target="_blank">
-									<?php esc_html_e( 'PNG to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
-								</a>
-							</p>
-				<?php endif; ?>
-				<?php if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_force_gif2webp' ) ) : ?>
-							<p class='description'>
-								<a href="https://ewww.io/plans/" target="_blank">
-									<?php esc_html_e( 'GIF to WebP conversion requires an active API key.', 'ewww-image-optimizer' ); ?>
-								</a>
-							</p>
-				<?php endif; ?>
 			<?php endif; ?>
 						</div>
 					</div>

--- a/common.php
+++ b/common.php
@@ -13631,8 +13631,8 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 					</div>
 				</div>
 	<?php endif; ?>
-				<div class='ewww-settings-section'>
 	<?php if ( ewwwio()->perfect_images_easyio_domain() ) : ?>
+				<div class='ewww-settings-section'>
 					<div id='ewww_image_optimizer_exactdn_container' class='ewww-settings-row ewwwio-premium-setup'>
 						<div class='ewww-setting-header'>
 							<span id='ewwwio-exactdn-anchor'></span>
@@ -13645,7 +13645,8 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 						</div>
 					</div>
 	<?php elseif ( ! get_option( 'easyio_exactdn' ) ) : ?>
-		<?php ob_start(); ?>
+				<div class='ewww-settings-section'>
+		<?php ob_start(); // Intentionally after the ewww-settings-section, as this will be wrapped in a section later, if needed. ?>
 					<div id='ewww_image_optimizer_exactdn_container' class='ewww-settings-row ewwwio-premium-setup'>
 						<div class='ewww-setting-header'>
 							<span id='ewwwio-exactdn-anchor'></span>
@@ -13755,6 +13756,8 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 					</div>
 		<?php $exactdn_settings_row = ob_get_contents(); ?>
 		<?php ob_end_flush(); ?>
+	<?php else : ?>
+				<div class='ewww-settings-section' style='display: none;'>
 	<?php endif; ?>
 					<div class='ewww-settings-row ewwwio-exactdn-options exactdn-easy-options' <?php echo $exactdn_enabled ? '' : 'style="display:none;"'; ?>>
 						<div class='ewww-setting-header'>&nbsp;</div>
@@ -13908,10 +13911,13 @@ function ewww_image_optimizer_options( $network = 'singlesite' ) {
 							<label for='ewww_image_optimizer_lazy_load'><?php esc_html_e( 'Lazy Load', 'ewww-image-optimizer' ); ?></label>
 							<?php ewwwio_help_link( 'https://docs.ewww.io/article/74-lazy-load', '5c6c36ed042863543ccd2d9b' ); ?>
 						</div>
-						<div class='ewww-setting-detail'>
 	<?php if ( function_exists( 'easyio_get_option' ) && easyio_get_option( 'easyio_lazy_load' ) ) : ?>
+						<div class='ewww-setting-detail'>
 							<p class='description'><?php esc_html_e( 'Lazy Load enabled in Easy Image Optimizer.', 'ewww-image-optimizer' ); ?></p>
+						</div>
+					</div>
 	<?php else : ?>
+						<div class='ewww-setting-detail'>
 							<input type='checkbox' id='ewww_image_optimizer_lazy_load' name='ewww_image_optimizer_lazy_load' value='true' <?php checked( ewww_image_optimizer_get_option( 'ewww_image_optimizer_lazy_load' ) ); ?> />
 							<?php esc_html_e( 'Improves actual and perceived loading time as images will be loaded only as they enter (or are about to enter) the viewport.', 'ewww-image-optimizer' ); ?>
 		<?php if ( ewwwio_other_lazy_detected() ) : ?>

--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,11 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 * Feature requests can be viewed and submitted on our [feedback portal](https://feedback.ewww.io/b/features)
 * If you would like to help translate this plugin in your language, [join the team](https://translate.wordpress.org/projects/wp-plugins/ewww-image-optimizer/)
 
+= 8.1.3 =
+*Release Date - TBD*
+
+* fixed: WebP rewriters alter PNG URLs when PNG to WebP conversion is unavailable
+
 = 8.1.2 =
 *Release Date - March 6, 2025*
 


### PR DESCRIPTION
Use the JPG-only option/indicator to limit WebP conversion and rewriting to JPG images. This helps especially with Force WebP mode, so that the plugin doesn't rewrite PNG images since conversion was particularly hit/miss with those. Also added a note by WebP Conversion so it is clear that PNG images will not be converted in free JPG-only mode.