### PR TITLE
rework async to avoid translation issues

### DIFF
--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -203,6 +203,10 @@ final class Plugin extends Base {
 			// For classes we need everywhere, front-end and back-end. Others are only included on admin_init (below).
 			self::$instance->requires();
 			self::$instance->load_children();
+			// Load async classes early, even though cron schedules use translations, and should not normally be loaded any earlier than init.
+			// The async classes have been modified to not use translations any earlier than init.
+			self::$instance->load_async_children();
+
 			// Load plugin compatibility functions for S3 Uploads, NextGEN, FlaGallery, and Nextcellent.
 			\add_action( 'plugins_loaded', array( self::$instance, 'plugins_compat' ) );
 			// Initializes the plugin for admin interactions, like saving network settings and scheduling cron jobs.
@@ -657,9 +661,6 @@ final class Plugin extends Base {
 	 */
 	public function init() {
 		$this->debug_message( '<b>' . __FUNCTION__ . '()</b>' );
-
-		// Load async classes on 'init', as cron schedules use translations, and those should not be loaded any earlier than init.
-		$this->load_async_children();
 
 		// For the settings page, check for the enable-local param and take appropriate action.
 		if ( ! empty( $_GET['enable-local'] ) && ! empty( $_REQUEST['_wpnonce'] ) && \wp_verify_nonce( \sanitize_key( $_REQUEST['_wpnonce'] ), 'ewww_image_optimizer_options-options' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 * fixed: Easy IO rewriting some URLs when full page exclusions are used
 * fixed: WebP rewriters alter PNG URLs when PNG to WebP conversion is unavailable
 * fixed: regression in compatibility with plugins that recreate images via WP_Image_Editor
+* fixed: previous fix to avoid translation notices caused errors with other plugins calling background processes earlier than 'init'
 
 = 8.1.2 =
 *Release Date - March 6, 2025*


### PR DESCRIPTION
Moved async classes back to early loading/initialization so that actions triggered by other plugins do not cause errors. 

Added conditional scheduling to dispatch() method. If 'init' has already run, then it is safe to schedule the healthcheck. Otherwise, hook schedule_event() onto 'init'.

Lastly, other plugins might still try to run wp_schedule_event() prior to 'init', which will then trigger the add_healthcheck_cron_schedule() method. To avoid translation errors, detect if add_healthcheck_cron_schedule() is called before 'init'. If so, don't use translations, they won't likely be seen anyway, as it's an abnormal case.