### PR TITLE
fix orientation when creating webp thumbs from original

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,12 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 * Feature requests can be viewed and submitted on our [feedback portal](https://feedback.ewww.io/b/features)
 * If you would like to help translate this plugin in your language, [join the team](https://translate.wordpress.org/projects/wp-plugins/ewww-image-optimizer/)
 
+= 8.1.4 =
+*Release Date - TBA*
+
+* added: customize lossy PDF compression by defining EWWW_IMAGE_OPTIMIZER_PDF_IMAGE_DPI and/or EWWW_IMAGE_OPTIMIZER_PDF_IMAGE_QUALITY
+* fixed: WebP thumbnails have incorrect orientation when created from the original unoptimized image
+
 = 8.1.3 =
 *Release Date - March 26, 2025*
 


### PR DESCRIPTION
Auto-rotate the original to prevent messing up the orientation of the WebP thumbs. If the original still has an orientation flag that is higher than 1, perform WebP generation from the existing thumb/size instead.