### PR TITLE
Improved Imagick png8 resize colortype detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ php:
   - 7.4
   - 8.1
   - 8.2
-  - 8.4
+  - 8.3
 
 services:
   - mysql
@@ -29,7 +29,7 @@ jobs:
   include:
     - php: 7.4
       env: WP_VERSION=latest WP_MULTISITE=1 WPSNIFF=1
-    - php: 8.4
+    - php: 8.3
       env: WP_VERSION=latest WP_MULTISITE=1 WPSNIFF=1
     - php: 8.1
       env: WP_VERSION=6.5 WP_MULTISITE=0

--- a/classes/class-ewwwio-imagick-editor.php
+++ b/classes/class-ewwwio-imagick-editor.php
@@ -77,6 +77,10 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 		if ( 'image/png' !== $this->mime_type ) {
 			return;
 		}
+		if ( method_exists( $this->image, 'getImageProperty' ) ) {
+			$color_type = $this->image->getImageProperty( 'png:IHDR.color-type-orig' );
+			\ewwwio_debug_message( "original color type is $color_type" );
+		}
 		if ( wp_is_stream( $this->file ) ) {
 			return;
 		}
@@ -447,6 +451,10 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 					$this->image->setOption( 'png:include-chunk', 'tRNS' );
 				} else {
 					$this->image->setOption( 'png:exclude-chunk', 'all' );
+				}
+				if ( method_exists( $this->image, 'getImageProperty' ) ) {
+					$color_type = $this->image->getImageProperty( 'png:IHDR.color-type-orig' );
+					\ewwwio_debug_message( "current color type is $color_type" );
 				}
 			}
 

--- a/classes/class-ewwwio-imagick-editor.php
+++ b/classes/class-ewwwio-imagick-editor.php
@@ -68,38 +68,38 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 	/**
 	 * Gets the bit depth for PNG images and checks for indexed-color mode.
 	 *
-	 * Access the file directly, as we cannot currently rely on Imagick to identify
-	 * palette images with alpha support.
+	 * Access the file directly, in case Imagick fails to identify the number of colors in an indexed image.
 	 *
-	 * @since 6.6.0
+	 * @since 7.7.0
+	 * @since 8.1.5 Only used to get the bit depth when IM returns 8 and getImageColors() isn't working.
+	 *
+	 * @return int The bit depth for PNG images, 8 by default.
 	 */
 	protected function get_png_color_depth() {
+		ewwwio_debug_message( '<b>' . __METHOD__ . '()</b>' );
+		$bit_depth = 8;
 		if ( 'image/png' !== $this->mime_type ) {
-			return;
-		}
-		if ( method_exists( $this->image, 'getImageProperty' ) ) {
-			$color_type = $this->image->getImageProperty( 'png:IHDR.color-type-orig' );
-			\ewwwio_debug_message( "original color type is $color_type" );
+			return $bit_depth;
 		}
 		if ( wp_is_stream( $this->file ) ) {
-			return;
+			return $bit_depth;
 		}
 		if ( ! is_file( $this->file ) ) {
-			return;
+			return $bit_depth;
 		}
 		if ( filesize( $this->file ) < 24 ) {
-			return;
+			return $bit_depth;
 		}
 
 		$file_handle = fopen( $this->file, 'rb' );
 
 		if ( ! $file_handle ) {
-			return;
+			return $bit_depth;
 		}
 
 		$png_header = fread( $file_handle, 4 );
 		if ( chr( 0x89 ) . 'PNG' !== $png_header ) {
-			return;
+			return $bit_depth;
 		}
 
 		// Move forward 8 bytes.
@@ -108,7 +108,7 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 
 		// Make sure we have an IHDR.
 		if ( 'IHDR' !== $png_ihdr ) {
-			return;
+			return $bit_depth;
 		}
 
 		// Skip past the dimensions.
@@ -119,7 +119,7 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 		// per palette index (not per pixel).
 		//
 		// Valid values are 1, 2, 4, 8, and 16, although not all values are allowed for all color types.
-		$this->indexed_pixel_depth = ord( (string) fread( $file_handle, 1 ) );
+		$bit_depth = ord( (string) fread( $file_handle, 1 ) );
 
 		// Color type is a single-byte integer that describes the interpretation of the image data.
 		// Color type codes represent sums of the following values:
@@ -134,11 +134,10 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 		// Valid values are 0, 2, 3, 4, and 6.
 		$color_type = ord( (string) fread( $file_handle, 1 ) );
 
-		if ( 3 === (int) $color_type ) {
-			$this->indexed_color_encoded = true;
-		}
-
 		fclose( $file_handle );
+
+		ewwwio_debug_message( "detected bit depth $bit_depth, color type $color_type" );
+		return $bit_depth;
 	}
 
 	/**
@@ -349,14 +348,28 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 		}
 
 		if ( 'image/png' === $this->mime_type ) {
+			$color_type = '6';
+			if ( method_exists( $this->image, 'getImageProperty' ) ) {
+				$color_type = $this->image->getImageProperty( 'png:IHDR.color-type-orig' );
+			}
 			ewwwio_debug_message( 'this image is type: ' . $this->image->getImageType() );
-			$this->get_png_color_depth();
-			if ( $this->indexed_color_encoded ) {
+			ewwwio_debug_message( 'this image has color type: ' . $color_type );
+			if ( '3' === $color_type ) {
 				$current_colors = 500; // Fail-safe for more than any indexed PNG could have.
 				if ( is_callable( array( $this->image, 'getImageColors' ) ) ) {
 					$current_colors = $this->image->getImageColors();
+					ewwwio_debug_message( "image has $current_colors colors" );
 				}
-				switch ( $this->indexed_pixel_depth ) {
+				$bit_depth = 8;
+				if ( is_callable( array( $this->image, 'getImageDepth' ) ) ) {
+					$bit_depth = (int) $this->image->getImageDepth();
+					// Only use the direct file method if the current colors is higher than normal.
+					// We'll need an accurate bit depth in that case, to make sure we properly set the maximum.
+					if ( $bit_depth >= 8 && $current_colors > 256 ) {
+						$bit_depth = $this->get_png_color_depth();
+					}
+				}
+				switch ( $bit_depth ) {
 					case 8:
 						$max_colors = 255;
 						break;
@@ -373,7 +386,7 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 						$max_colors = 255;
 				}
 				$this->indexed_max_colors = min( $max_colors, $current_colors );
-				ewwwio_debug_message( "indexed image with pixel depth {$this->indexed_pixel_depth} limiting to {$this->indexed_max_colors} colors" );
+				ewwwio_debug_message( "indexed image with pixel depth {$bit_depth} limiting to {$this->indexed_max_colors} colors" );
 			}
 		}
 
@@ -444,32 +457,24 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 				$this->image->setOption( 'png:compression-filter', '5' );
 				$this->image->setOption( 'png:compression-level', '9' );
 				$this->image->setOption( 'png:compression-strategy', '1' );
-				if ( $this->indexed_color_encoded
-					&& is_callable( array( $this->image, 'getImageAlphaChannel' ) )
-					&& $this->image->getImageAlphaChannel()
-				) {
-					$this->image->setOption( 'png:include-chunk', 'tRNS' );
-				} else {
-					$this->image->setOption( 'png:exclude-chunk', 'all' );
-				}
-				if ( method_exists( $this->image, 'getImageProperty' ) ) {
-					$color_type = $this->image->getImageProperty( 'png:IHDR.color-type-orig' );
-					\ewwwio_debug_message( "current color type is $color_type" );
-				}
-			}
-
-			if ( $this->indexed_color_encoded ) {
-				if ( ! empty( $this->indexed_max_colors ) && ! ewww_image_optimizer_pngquant_reduce_available() ) {
-					ewwwio_debug_message( "doing quantizeImage on $this->file ($dst_w,$dst_h) to reduce palette to $this->indexed_max_colors" );
-					$this->image->quantizeImage( $this->indexed_max_colors, $this->image->getColorspace(), 0, false, false );
-					ewwwio_debug_message( "originally we had $current_colors colors, and now we have " . $this->image->getImageColors() );
-					/**
-					 * ImageMagick likes to convert gray indexed images to grayscale.
-					 * So, if the colorspace has changed to 'gray', use the png8 format
-					 * to ensure it stays indexed.
-					 */
-					if ( Imagick::COLORSPACE_GRAY === $this->image->getImageColorspace() ) {
-						$this->image->setOption( 'png:format', 'png8' );
+				if ( '3' === $color_type ) {
+					if ( is_callable( array( $this->image, 'getImageAlphaChannel' ) ) && $this->image->getImageAlphaChannel() ) {
+						$this->image->setOption( 'png:include-chunk', 'tRNS' );
+					} else {
+						$this->image->setOption( 'png:exclude-chunk', 'all' );
+					}
+					if ( ! empty( $this->indexed_max_colors ) && ! ewww_image_optimizer_pngquant_reduce_available() ) {
+						ewwwio_debug_message( "doing quantizeImage on $this->file ($dst_w,$dst_h) to reduce palette to $this->indexed_max_colors" );
+						$this->image->quantizeImage( $this->indexed_max_colors, $this->image->getColorspace(), 0, false, false );
+						ewwwio_debug_message( "originally we had $current_colors colors, and now we have " . $this->image->getImageColors() );
+						/**
+						 * ImageMagick likes to convert gray indexed images to grayscale.
+						 * So, if the colorspace has changed to 'gray', use the png8 format
+						 * to ensure it stays indexed.
+						 */
+						if ( Imagick::COLORSPACE_GRAY === $this->image->getImageColorspace() ) {
+							$this->image->setOption( 'png:format', 'png8' );
+						}
 					}
 				}
 			}
@@ -821,7 +826,7 @@ class EWWWIO_Imagick_Editor extends WP_Image_Editor_Imagick {
 		chmod( $filename, $perms );
 
 		if ( ewwwio_is_file( $filename ) ) {
-			if ( $this->indexed_color_encoded ) {
+			if ( $this->indexed_max_colors ) {
 				ewwwio_debug_message( "reducing to $this->indexed_max_colors colors" );
 				ewww_image_optimizer_reduce_palette( $filename, $this->indexed_max_colors );
 			}

--- a/common.php
+++ b/common.php
@@ -7877,6 +7877,8 @@ function ewww_image_optimizer_better_resize( $file, $dst_x, $dst_y, $src_x, $src
  */
 function ewww_image_optimizer_pngquant_reduce_available() {
 	ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
+	// From our testing, native IM reduction is generally fine, and file sizes are smaller.
+	// Thus, pngquant reduction (local or cloud) is only allowed if the user specifically defines the constant to 'true'.
 	if ( ! defined( 'EWWWIO_PNGQUANT_REDUCE' ) || ! EWWWIO_PNGQUANT_REDUCE ) {
 		return false;
 	}

--- a/ewww-image-optimizer.php
+++ b/ewww-image-optimizer.php
@@ -13,7 +13,7 @@ Plugin Name: EWWW Image Optimizer
 Plugin URI: https://wordpress.org/plugins/ewww-image-optimizer/
 Description: Smaller Images, Faster Sites, Happier Visitors. Comprehensive image optimization that doesn't require a degree in rocket science.
 Author: Exactly WWW
-Version: 8.1.4
+Version: 8.1.4.1
 Requires at least: 6.5
 Requires PHP: 7.4
 Author URI: https://ewww.io/
@@ -34,7 +34,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70400 ) {
 	add_action( 'admin_notices', 'ewww_image_optimizer_dual_plugin' );
 } elseif ( false === strpos( add_query_arg( '', '' ), 'ewwwio_disable=1' ) ) {
 
-	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 814 );
+	define( 'EWWW_IMAGE_OPTIMIZER_VERSION', 814.1 );
 
 	if ( WP_DEBUG && function_exists( 'memory_get_usage' ) ) {
 		$ewww_memory = 'plugin load: ' . memory_get_usage( true ) . "\n";

--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,11 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 * Feature requests can be viewed and submitted on our [feedback portal](https://feedback.ewww.io/b/features)
 * If you would like to help translate this plugin in your language, [join the team](https://translate.wordpress.org/projects/wp-plugins/ewww-image-optimizer/)
 
+= 8.1.5 =
+*Release Date - TBD*
+
+* changed: use native ImageMagick methods to detect, and correct, paletted PNG thumbnails
+
 = 8.1.4 =
 *Release Date - May 15, 2025*
 


### PR DESCRIPTION
It is possible to get the original color type value from the IHDR of a PNG file via the `getImageProperty` method. So instead of directly accessing the file to determine if the color type === 3 (indexed), we use the native method instead.
For the bit depth, `getImageDepth` works just fine on newer versions of IM. And if it doesn't, it is only a problem if `getImageColors` returns something higher than the 256 colors allowed for indexed images. In that rare case, the plugin can fall back to the revamped `get_png_color_depth` method to determine the true bit depth and constrain the number of colors appropriately.