### PR TITLE
add test mode setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ php:
   - 7.4
   - 8.1
   - 8.2
-  - 8.4
+  - 8.3
 
 services:
   - mysql
@@ -29,7 +29,7 @@ jobs:
   include:
     - php: 7.4
       env: WP_VERSION=latest WP_MULTISITE=1 WPSNIFF=1
-    - php: 8.4
+    - php: 8.3
       env: WP_VERSION=latest WP_MULTISITE=1 WPSNIFF=1
     - php: 8.1
       env: WP_VERSION=6.5 WP_MULTISITE=0

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -420,6 +420,24 @@ class Base {
 	}
 
 	/**
+	 * Checks to see if test mode is enabled, and whether the current user is a logged-in admin.
+	 *
+	 * @return bool True if test mode should be effective and prevent optimizations for guest users. False otherwise.
+	 */
+	public function test_mode_active() {
+		if (
+			$this->get_option( $this->prefix . 'test_mode' ) &&
+			( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) )
+		) {
+			if ( ! empty( $_GET['ewwwio_test_mode'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				return false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Escape any spaces in the filename.
 	 *
 	 * @param string $path The path to a binary file.

--- a/common.php
+++ b/common.php
@@ -625,6 +625,8 @@ function ewww_image_optimizer_save_network_settings() {
 			ewwwio_debug_message( 'network-wide settings, no override' );
 			$ewww_image_optimizer_debug = ( empty( $_POST['ewww_image_optimizer_debug'] ) ? false : true );
 			update_site_option( 'ewww_image_optimizer_debug', $ewww_image_optimizer_debug );
+			$ewww_image_optimizer_test_mode = ( empty( $_POST['ewww_image_optimizer_test_mode'] ) ? false : true );
+			update_site_option( 'ewww_image_optimizer_test_mode', $ewww_image_optimizer_test_mode );
 			$ewww_image_optimizer_metadata_remove = ( empty( $_POST['ewww_image_optimizer_metadata_remove'] ) ? false : true );
 			update_site_option( 'ewww_image_optimizer_metadata_remove', $ewww_image_optimizer_metadata_remove );
 			$ewww_image_optimizer_jpg_level = empty( $_POST['ewww_image_optimizer_jpg_level'] ) ? '' : (int) $_POST['ewww_image_optimizer_jpg_level'];
@@ -1896,7 +1898,7 @@ function ewww_image_optimizer_notice_exactdn_sp_conflict() {
  * Display a notice that debugging mode is enabled.
  */
 function ewww_image_optimizer_debug_enabled_notice() {
-	if ( ! current_user_can( apply_filters( 'ewww_image_optimizer_admin_permissions', '' ) ) ) {
+	if ( ! ewww_image_optimizer_get_option( 'ewww_image_optimizer_debug' ) ) {
 		return;
 	}
 	?>
@@ -11776,6 +11778,7 @@ function ewwwio_debug_info() {
 	global $ewwwio_upgrading;
 	global $content_width;
 	ewwwio_debug_version_info();
+	ewwwio_debug_message( 'test mode: ' . ( ewww_image_optimizer_get_option( 'ewww_image_optimizer_test_mode' ) ? 'on' : 'off' ) );
 	ewwwio_debug_message( 'ABSPATH: ' . ABSPATH );
 	ewwwio_debug_message( 'WP_CONTENT_DIR: ' . WP_CONTENT_DIR );
 	ewwwio_debug_message( 'EWWWIO_CONTENT_DIR: ' . EWWWIO_CONTENT_DIR );
@@ -15097,6 +15100,15 @@ AddType image/webp .webp</pre>
 					</div>
 				</div>
 				<div class='ewww-settings-section'>
+					<div class='ewww-settings-row'>
+						<div class='ewww-setting-header'>
+							<label for='ewww_image_optimizer_test_mode'><?php esc_html_e( 'Test Mode', 'ewww-image-optimizer' ); ?></label>
+						</div>
+						<div class='ewww-setting-detail'>
+							<input type='checkbox' id='ewww_image_optimizer_test_mode' name='ewww_image_optimizer_test_mode' value='true' <?php checked( ewww_image_optimizer_get_option( 'ewww_image_optimizer_test_mode' ) ); ?> />
+							<span><?php esc_html_e( 'Limits front-end optimizations to logged-in admins to allow troubleshooting without affecting visitors and other users.', 'ewww-image-optimizer' ); ?></span>
+						</div>
+					</div>
 					<div class='ewww-settings-row'>
 						<div class='ewww-setting-header'>
 							<label for='ewww_image_optimizer_debug'><?php esc_html_e( 'Debugging', 'ewww-image-optimizer' ); ?></label>


### PR DESCRIPTION
Test Mode disables all 4 front-end parsers, so that only logged-in admins can see the site with those enabled.
There is an ewwwio_test_mode query param that can be used to enable the parsers for that page load, without logging in.
Added a generic admin_notice method to consolidate more notices, only used for debugging and test mode currently.