### PR TITLE
Imagick png8 grayscale alpha

### DIFF
--- a/common.php
+++ b/common.php
@@ -7901,14 +7901,15 @@ function ewww_image_optimizer_pngquant_reduce_available() {
  *
  * @param string $file A PNG image file.
  * @param int    $max_colors The maximum number of colors.
+ * @param bool   $problematic_grayscale Optional. Whether a problematic grayscale image needs further reduction. Default false.
  */
-function ewww_image_optimizer_reduce_palette( $file, $max_colors ) {
+function ewww_image_optimizer_reduce_palette( $file, $max_colors, $problematic_grayscale = false ) {
 	ewwwio_debug_message( '<b>' . __FUNCTION__ . '()</b>' );
 	if ( ! apply_filters( 'ewww_image_optimizer_reduce_palette', true ) ) {
 		ewwwio_debug_message( 'palette reduction disabled' );
 		return;
 	}
-	if ( ! defined( 'EWWWIO_PNGQUANT_REDUCE' ) || ! EWWWIO_PNGQUANT_REDUCE ) {
+	if ( ( ! $problematic_grayscale && ! defined( 'EWWWIO_PNGQUANT_REDUCE' ) ) || ( defined( 'EWWWIO_PNGQUANT_REDUCE' ) && ! EWWWIO_PNGQUANT_REDUCE ) ) {
 		return false;
 	}
 	ewwwio_debug_message( "reducing $file to $max_colors colors" );

--- a/readme.txt
+++ b/readme.txt
@@ -149,6 +149,7 @@ That's not a question, but since I made it up, I'll answer it. See this resource
 
 * changed: use native ImageMagick methods to detect, and correct, paletted PNG thumbnails
 * changed: use authoritative classmap via composer to speed up autoloader, props @nlemoine
+* fixed: indexed PNG thumbnails with 8-bit alpha are distorted by quantization
 
 = 8.1.4 =
 *Release Date - May 15, 2025*


### PR DESCRIPTION
When an indexed image is gray, ImageMagick has a bad habit of converting it to Grayscale mode, which uses more bytes.
This can be fixed with png:format=png8, unless the image has an alpha channel with a bit depth > 1. That is, simple transparency with 1 bit alpha can be handled by the png8 hack, but anything beyond that gets ugly.
There's no other way to handle that in ImageMagick, but we can use pngquant to reduce the palette on such problematic images.