### PR TITLE
Add filters for third-party S3 offload plugin integration (#384)

### DIFF
--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -1814,6 +1814,35 @@ class Base {
 			}
 		}
 
+		/**
+		 * Allow third-party offload plugins to mark the site as serving media from S3-compatible storage.
+		 *
+		 * Built-in detection covers WP Offload Media, S3 Uploads, and WP Stateless. Other offloaders
+		 * (e.g. Advanced Media Offloader) can hook this filter to opt in.
+		 *
+		 * @param bool|string $s3_active False when no S3 offload is active, otherwise the S3/CDN host
+		 *                               that should be matched against asset URLs.
+		 */
+		$this->s3_active = \apply_filters( 'eio_s3_active', $this->s3_active );
+
+		/**
+		 * Allow third-party offload plugins to declare an S3 object prefix.
+		 *
+		 * The prefix is stripped from URLs when mapping CDN URLs back to local paths.
+		 *
+		 * @param string $s3_object_prefix The object prefix, or an empty string when none is used.
+		 */
+		$this->s3_object_prefix = \apply_filters( 'eio_s3_object_prefix', $this->s3_object_prefix );
+
+		/**
+		 * Allow third-party offload plugins to declare that offloaded URLs contain a numeric
+		 * object versioning segment (8 or 14 digits) that must be stripped before resolving
+		 * URLs to local paths.
+		 *
+		 * @param bool $s3_object_version True when offloaded URLs contain a versioning segment.
+		 */
+		$this->s3_object_version = \apply_filters( 'eio_s3_object_versioning_enabled', $this->s3_object_version );
+
 		// NOTE: we don't want this for Easy IO as they might be using SWIS to deliver
 		// JS/CSS from a different CDN domain, and that will break with Easy IO!
 		if ( __NAMESPACE__ . '\ExactDN' !== \get_class( $this ) && __NAMESPACE__ . '\Base' !== \get_class( $this ) && \function_exists( '\swis' ) && \is_object( \swis()->settings ) && \swis()->settings->get_option( 'cdn_domain' ) ) {


### PR DESCRIPTION
## Summary

Implements option B from #384: exposes three filters in `EWWW\Base::content_url()` so offload plugins other than WP Offload Media can declare themselves to EWWW without patching the plugin.

| Filter | Property | Purpose |
| --- | --- | --- |
| `eio_s3_active` | `$s3_active` | Mark the site as serving media from S3-compatible storage and provide the host to match against asset URLs. |
| `eio_s3_object_prefix` | `$s3_object_prefix` | Declare an S3 object prefix to strip when mapping CDN URLs back to local paths. |
| `eio_s3_object_versioning_enabled` | `$s3_object_version` | Declare that offloaded URLs contain an 8/14-digit versioning segment to be stripped by `maybe_strip_object_version()`. |

## Background

`$s3_object_version` was previously only set by the WP Offload Media (AS3CF) detection block. With any other offloader that uses numeric object versioning in S3 keys (e.g. Advanced Media Offloader), `maybe_strip_object_version()` returned URLs unchanged, `url_to_path_exists()` searched for a local file that included the versioning segment, `validate_image_url()` silently returned `false`, and Picture WebP / JS WebP / Lazy Load rewriting was effectively disabled for every offloaded image.

Per @nosilver4u's comment on #384, option B is preferable and more future-proof, and `$s3_active` and `$s3_object_prefix` are now also filterable so plugin authors can bridge the gap from their side for any cloud storage integration.

## Implementation notes

- Filters are applied at the end of the built-in detection in `content_url()` (after AS3CF / S3 Uploads / WP Stateless), before `$this->s3_active` is consumed downstream — so built-in detection still wins when present, and third-party hooks can fill in the gap when none of the bundled detection paths fire.
- No behavioral change for existing setups: the filters default to the values produced by built-in detection.
- `maybe_strip_object_version()` already only strips a segment that is exactly 8 or 14 consecutive digits, so standard WordPress date folders (`/2024/01/`) are never touched — opting in via the filter is safe.

## Test plan

- [x] PHP lint clean (`php -l classes/class-base.php`)
- [x] To verify: with `add_filter( 'eio_s3_object_versioning_enabled', '__return_true' );` on an Advanced Media Offloader 4.4.1 install, Picture WebP wraps offloaded `<img>` tags and emits `<source type="image/webp">` pointing at the `.webp` sidecar on the CDN; JS WebP and Lazy Load rewrite as expected
- [x] To verify: no behavior change on a site using WP Offload Media with `object-versioning` enabled (built-in detection still sets the property to `true` before the filter runs)

Original failure mode (no filter present) was reproduced on Advanced Media Offloader 4.4.1 during issue investigation — see #384 for the full debug trace.

Fixes #384